### PR TITLE
Move libraries to the end of the link line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ CODESIGN_SRCS = codesign.cpp $(COMMON_SRCS)
 CODESIGN_OBJS := $(CODESIGN_SRCS:.cpp=.o)
 
 CPPFLAGS := -I vendor $(shell $(PKG_CONFIG) --cflags openssl)
-LDFLAGS := $(shell $(PKG_CONFIG) --libs openssl)
+LIBS := $(shell $(PKG_CONFIG) --libs openssl)
 
 sigtool: $(SIGTOOL_OBJS)
-	$(CXX) $(LDFLAGS) -o $@ $^
+	$(CXX) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 codesign: $(CODESIGN_OBJS)
-	$(CXX) $(LDFLAGS) -o $@ $^
+	$(CXX) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 .PHONY: install
 install: sigtool codesign


### PR DESCRIPTION
Move libraries to the end of the link line to avoid errors like:

```
g++ -lssl -lcrypto -o sigtool main.o hash.o macho.o signature.o commands.o
/usr/bin/ld: hash.o: in function `SigTool::SHA256Hash::SHA256Hash(unsigned char const*, unsigned long)':
hash.cpp:(.text+0xcc): undefined reference to `SHA256'
collect2: error: ld returned 1 exit status
make: *** [Makefile:18: sigtool] Error 1
```

The link line is updated to be something like:

```
g++  -o sigtool main.o hash.o macho.o signature.o commands.o -lssl -lcrypto
```