### PR TITLE
Support -o runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Options:
   -i,--identifier TEXT        File identifier
   -e,--entitlements TEXT      Entitlements plist
   --generate-entitlement-der  Also embed DER-encoded entitlements
+  --hardened-runtime          Enable hardened runtime (sets CS_RUNTIME flag)
 
 Subcommands:
   check-requires-signature    Determine if this is a macho file that must be signed
@@ -53,12 +54,20 @@ Options:
   --entitlements TEXT         Entitlements plist
   --generate-entitlement-der  Also embed DER-encoded entitlements
   --timestamp[=none]          Accepted for compatibility; only =none is supported
+  -o,--options TEXT           Comma-separated signing options (only "runtime" supported)
 ```
 
 `--timestamp=none` is accepted as a no-op so build tools that pass it can call
 this `codesign` unmodified. Real TSA timestamping is not supported because
 ad-hoc signatures contain no CMS signature for a timestamp authority to
 countersign.
+
+### Hardened runtime
+
+`-o runtime` (or `--options=runtime`) enables the hardened runtime: bumps the
+CodeDirectory to v=0x20500, sets the `CS_RUNTIME` flag, and emits the runtime
+field. Other `-o` options (`library`, `kill`, etc.) are not supported and will
+error.
 
 ## Example signature
 

--- a/codesign.cpp
+++ b/codesign.cpp
@@ -4,7 +4,7 @@
 int main(int argc, char **argv) {
     CLI::App app{"codesign"};
 
-    std::string identity, identifier, entitlements, timestamp;
+    std::string identity, identifier, entitlements, timestamp, optionsFlags;
     bool force = false;
     bool generateEntitlementDER = false;
     std::vector<std::string> files;
@@ -23,6 +23,8 @@ int main(int argc, char **argv) {
     // "true", which is rejected below like any value other than "none".
     app.add_flag("--timestamp", timestamp,
                  "Timestamp options; only '--timestamp=none' is supported");
+    app.add_option("-o,--options", optionsFlags,
+                   "Comma-separated signing options; only 'runtime' is supported");
     app.add_option("files", files, "Files to sign");
 
     CLI11_PARSE(app, argc, argv);
@@ -38,11 +40,31 @@ int main(int argc, char **argv) {
                 std::string{"Only ad-hoc identities supported, requested: '"} + identity + "'"};
     }
 
+    bool hardenedRuntime = false;
+    if (!optionsFlags.empty()) {
+        size_t start = 0;
+        while (start <= optionsFlags.size()) {
+            size_t comma = optionsFlags.find(',', start);
+            if (comma == std::string::npos) comma = optionsFlags.size();
+            std::string opt = optionsFlags.substr(start, comma - start);
+            if (opt == "runtime") {
+                hardenedRuntime = true;
+            } else if (!opt.empty()) {
+                throw std::runtime_error{
+                        "-o option '" + opt + "' is not supported "
+                        "(only 'runtime' is recognised)"};
+            }
+            if (comma == optionsFlags.size()) break;
+            start = comma + 1;
+        }
+    }
+
     SigTool::Commands::CodesignOptions options{
             .identifier = identifier,
             .entitlements = entitlements,
             .force = force,
             .generateEntitlementDER = generateEntitlementDER,
+            .hardenedRuntime = hardenedRuntime,
     };
 
     for (const auto &f : files) {

--- a/commands.cpp
+++ b/commands.cpp
@@ -98,6 +98,10 @@ static SuperBlob signMachO(
         codeDirectory->data.execSegFlags |= CS_EXECSEG_MAIN_BINARY;
     }
 
+    if (options.hardenedRuntime) {
+        codeDirectory->setHardenedRuntime(target->sdkVersion());
+    }
+
     auto textSegment = target->getSegment64LoadCommand("__TEXT");
     if (textSegment) {
         codeDirectory->data.execSegBase = textSegment->data.fileoff;
@@ -286,6 +290,7 @@ int Commands::codesign(const CodesignOptions &options, const std::string &filena
                 .identifier = identifier,
                 .entitlements = options.entitlements,
                 .generateEntitlementDER = options.generateEntitlementDER,
+                .hardenedRuntime = options.hardenedRuntime,
         }, macho);
 
 
@@ -356,6 +361,7 @@ int Commands::codesign(const CodesignOptions &options, const std::string &filena
             .identifier = identifier,
             .entitlements = options.entitlements,
             .generateEntitlementDER = options.generateEntitlementDER,
+            .hardenedRuntime = options.hardenedRuntime,
     });
 
     // rename temp file to output

--- a/commands.h
+++ b/commands.h
@@ -10,6 +10,7 @@ namespace Commands {
         std::string identifier;
         std::string entitlements;
         bool generateEntitlementDER;
+        bool hardenedRuntime;
     };
 
     struct CodesignOptions {
@@ -17,6 +18,7 @@ namespace Commands {
         std::string entitlements;
         bool force;
         bool generateEntitlementDER;
+        bool hardenedRuntime;
     };
 
     int checkRequiresSignature(const std::string &file);

--- a/macho.cpp
+++ b/macho.cpp
@@ -80,6 +80,25 @@ MachO::MachO(std::ifstream &f, off_t offset, size_t size) : header{}, offset{off
                 break;
             }
 
+            case LC_BUILD_VERSION: {
+                auto lcBuildVersion = std::make_shared<BuildVersionLoadCommand>(type, cmdSize);
+                f.read(reinterpret_cast<char *>(&lcBuildVersion->data),
+                       sizeof(BuildVersionLoadCommand::data));
+                loadCommands.push_back(lcBuildVersion);
+                break;
+            }
+
+            case LC_VERSION_MIN_MACOSX:
+            case LC_VERSION_MIN_IPHONEOS:
+            case LC_VERSION_MIN_TVOS:
+            case LC_VERSION_MIN_WATCHOS: {
+                auto lcVersionMin = std::make_shared<VersionMinLoadCommand>(type, cmdSize);
+                f.read(reinterpret_cast<char *>(&lcVersionMin->data),
+                       sizeof(VersionMinLoadCommand::data));
+                loadCommands.push_back(lcVersionMin);
+                break;
+            }
+
             case LC_CODE_SIGNATURE: {
                 auto lcCodeSignature = std::make_shared<CodeSignatureLoadCommand>(type, cmdSize);
                 f.read(reinterpret_cast<char *>(&lcCodeSignature->data),
@@ -129,6 +148,26 @@ std::shared_ptr<CodeSignatureLoadCommand> MachO::getCodeSignatureLoadCommand() {
         return std::static_pointer_cast<CodeSignatureLoadCommand>(lc);
     }
     return std::shared_ptr<CodeSignatureLoadCommand>{};
+}
+
+uint32_t MachO::sdkVersion() {
+    for (const auto &lc : loadCommands) {
+        if (lc->type == LC_BUILD_VERSION) {
+            return std::static_pointer_cast<BuildVersionLoadCommand>(lc)->data.sdk;
+        }
+    }
+
+    for (const auto &lc : loadCommands) {
+        switch (lc->type) {
+            case LC_VERSION_MIN_MACOSX:
+            case LC_VERSION_MIN_IPHONEOS:
+            case LC_VERSION_MIN_TVOS:
+            case LC_VERSION_MIN_WATCHOS:
+                return std::static_pointer_cast<VersionMinLoadCommand>(lc)->data.sdk;
+        }
+    }
+
+    return 0;
 }
 
 bool MachO::requiresSignature() {

--- a/macho.h
+++ b/macho.h
@@ -54,6 +54,11 @@ enum {
 enum LCType {
     LC_CODE_SIGNATURE = 0x1d,
     LC_SEGMENT_64 = 0x19,
+    LC_VERSION_MIN_MACOSX = 0x24,
+    LC_VERSION_MIN_IPHONEOS = 0x25,
+    LC_VERSION_MIN_TVOS = 0x2f,
+    LC_VERSION_MIN_WATCHOS = 0x30,
+    LC_BUILD_VERSION = 0x32,
 };
 
 struct MachOHeader {
@@ -94,6 +99,30 @@ struct Segment64LoadCommand : public LoadCommand {
     } __attribute__((packed)) data{};
 };
 
+// LC_BUILD_VERSION; minos/sdk are X.Y.Z packed in nibbles as xxxx.yy.zz
+struct BuildVersionLoadCommand : public LoadCommand {
+    explicit BuildVersionLoadCommand(uint32_t type, uint32_t cmdSize)
+            : LoadCommand(type, cmdSize) {};
+
+    struct {
+        uint32_t platform;
+        uint32_t minos;
+        uint32_t sdk;
+        uint32_t ntools;
+    } __attribute__((packed)) data{};
+};
+
+// LC_VERSION_MIN_*; version/sdk are X.Y.Z packed in nibbles as xxxx.yy.zz
+struct VersionMinLoadCommand : public LoadCommand {
+    explicit VersionMinLoadCommand(uint32_t type, uint32_t cmdSize)
+            : LoadCommand(type, cmdSize) {};
+
+    struct {
+        uint32_t version;
+        uint32_t sdk;
+    } __attribute__((packed)) data{};
+};
+
 struct CodeSignatureLoadCommand : public LoadCommand {
     explicit CodeSignatureLoadCommand(uint32_t type, uint32_t cmdSize)
             : LoadCommand(type, cmdSize) {};
@@ -115,6 +144,10 @@ struct MachO {
     std::shared_ptr<Segment64LoadCommand> getSegment64LoadCommand(const std::string &name);
 
     std::shared_ptr<CodeSignatureLoadCommand> getCodeSignatureLoadCommand();
+
+    // SDK version this slice was built against, in the packed nibble form
+    // used by LC_BUILD_VERSION / LC_VERSION_MIN_* (xxxx.yy.zz). 0 if unknown.
+    uint32_t sdkVersion();
 
     bool requiresSignature();
 

--- a/magic_numbers.h
+++ b/magic_numbers.h
@@ -5,6 +5,7 @@ namespace SigTool {
 
 enum {
     CS_ADHOC = 0x00000002,
+    CS_RUNTIME = 0x00010000,
 };
 
 enum {

--- a/main.cpp
+++ b/main.cpp
@@ -7,12 +7,15 @@ int main(int argc, char **argv) {
 
     std::string file, identifier, entitlements;
     bool generateEntitlementDER = false;
+    bool hardenedRuntime = false;
     app.add_option("-f,--file", file, "Mach-O target file")
             ->required();
     app.add_option("-i,--identifier", identifier, "File identifier");
     app.add_option("-e,--entitlements", entitlements, "Entitlements plist");
     app.add_flag("--generate-entitlement-der", generateEntitlementDER,
                  "Also embed DER-encoded entitlements");
+    app.add_flag("--hardened-runtime", hardenedRuntime,
+                 "Enable hardened runtime (sets CS_RUNTIME flag)");
 
     app.add_subcommand("check-requires-signature",
                        "Determine if this is a macho file that must be signed");
@@ -37,6 +40,7 @@ int main(int argc, char **argv) {
             .identifier = identifier,
             .entitlements = entitlements,
             .generateEntitlementDER = generateEntitlementDER,
+            .hardenedRuntime = hardenedRuntime,
     };
 
     if (app.got_subcommand("size")) {

--- a/signature.cpp
+++ b/signature.cpp
@@ -18,8 +18,16 @@ CodeDirectory::CodeDirectory() noexcept {
     data.hashType = Hash::hashType;
 }
 
+// Fixed-header size for a given CodeDirectory version. Variable parts (ident,
+// hashes) follow.
+static size_t headerSizeForVersion(uint32_t version) {
+    if (version >= 0x20500) return sizeof(CodeDirectory::data_t);
+    // Strip the trailing v=0x20500 fields (runtime + preEncryptionOffset, 8 bytes).
+    return sizeof(CodeDirectory::data_t) - 8;
+}
+
 size_t CodeDirectory::length() {
-    size_t length = sizeof(data);
+    size_t length = headerSizeForVersion(data.version);
     length += identifier.length() + 1;
     length += sizeof(Hash::bytes) * (data.nSpecialSlots + data.nCodeSlots);
     return length;
@@ -27,7 +35,7 @@ size_t CodeDirectory::length() {
 
 void CodeDirectory::emit(std::ostream& os)  {
     // Layout variable length components
-    off_t tail = sizeof(data);
+    off_t tail = headerSizeForVersion(data.version);
 
     data.identOffset = tail;
     tail += identifier.length() + 1;
@@ -59,6 +67,10 @@ void CodeDirectory::emit(std::ostream& os)  {
     EmitBE::writeUInt64(os, data.execSegBase);
     EmitBE::writeUInt64(os, data.execSegLimit);
     EmitBE::writeUInt64(os, data.execSegFlags);
+    if (data.version >= 0x20500) {
+        EmitBE::writeUInt32(os, data.runtime);
+        EmitBE::writeUInt32(os, data.preEncryptionOffset);
+    }
 
     // Followed by variable length components
     os.write(identifier.c_str(), identifier.length());
@@ -99,6 +111,12 @@ void CodeDirectory::setCodeLimit(uint64_t codeLimit) {
 void CodeDirectory::addCodeHash(const Hash& value) {
     codeHashes.push_back(value);
     data.nCodeSlots = codeHashes.size();
+}
+
+void CodeDirectory::setHardenedRuntime(uint32_t runtimeVersion) {
+    data.version = std::max(data.version, uint32_t{0x20500});
+    data.flags |= CS_RUNTIME;
+    data.runtime = runtimeVersion;
 }
 
 void SuperBlob::emit(std::ostream& os)  {

--- a/signature.h
+++ b/signature.h
@@ -54,6 +54,9 @@ struct CodeDirectory : public Blob {
         uint64_t execSegBase;
         uint64_t execSegLimit;
         uint64_t execSegFlags;
+        // v=0x20500 fields (emitted only when version >= 0x20500)
+        uint32_t runtime;
+        uint32_t preEncryptionOffset;
     } __attribute__((packed)) data {};
 
 
@@ -69,6 +72,9 @@ struct CodeDirectory : public Blob {
     void setPageSize(uint16_t pageSize);
     void setCodeLimit(uint64_t codeLimit);
     void addCodeHash(const Hash& value);
+    // Enable hardened runtime: sets CS_RUNTIME flag, bumps version to 0x20500,
+    // and writes the runtime field (SDK version, packed nibble form).
+    void setHardenedRuntime(uint32_t runtimeVersion);
 
     std::string identifier;
     std::vector<Hash> codeHashes;


### PR DESCRIPTION
This also requires reading the SDK version from headers to match the apple behaviour.

This is required for swift-build support.