### PR TITLE
Implement bundle signing (including nested)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ pkg_check_modules(LIBPLIST REQUIRED IMPORTED_TARGET libplist-2.0)
 
 set(CMAKE_CXX_STANDARD 11)
 
-add_library(libsigtool macho.cpp signature.cpp hash.cpp commands.cpp der.cpp)
+add_library(libsigtool macho.cpp signature.cpp hash.cpp commands.cpp der.cpp bundle.cpp resources.cpp)
 target_include_directories(libsigtool PUBLIC vendor)
 target_link_libraries(libsigtool PRIVATE OpenSSL::Crypto PkgConfig::LIBPLIST)
 set_property(TARGET libsigtool PROPERTY OUTPUT_NAME sigtool)
@@ -28,10 +28,12 @@ install(TARGETS sigtool codesign libsigtool)
 
 install(
   FILES
+    bundle.h
     commands.h
     emit.h
     hash.h
     macho.h
+    resources.h
     signature.h
   DESTINATION
     include/sigtool

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 PKG_CONFIG ?= pkg-config
 CXXFLAGS = -std=c++11
 
-COMMON_SRCS = hash.cpp macho.cpp signature.cpp commands.cpp der.cpp
+COMMON_SRCS = hash.cpp macho.cpp signature.cpp commands.cpp der.cpp bundle.cpp resources.cpp
 
 SIGTOOL_SRCS = main.cpp $(COMMON_SRCS)
 SIGTOOL_OBJS := $(SIGTOOL_SRCS:.cpp=.o)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,23 @@ CodeDirectory to v=0x20500, sets the `CS_RUNTIME` flag, and emits the runtime
 field. Other `-o` options (`library`, `kill`, etc.) are not supported and will
 error.
 
+### Bundle signing
+
+`codesign` accepts a path to a `.framework`, `.app`, `.bundle`, or `.xpc`
+directory (or a `Foo.framework/Versions/X` subpath). For bundles it:
+
+  - reads `CFBundleIdentifier` from `Info.plist` (XML or binary plist) as the
+    default signing identifier
+  - walks bundle resources, computes SHA-1 + SHA-256 hashes, and writes
+    `_CodeSignature/CodeResources` matching Apple's default rules
+  - hashes `Info.plist` into CodeDirectory special slot 1
+  - hashes `CodeResources` into CodeDirectory special slot 3
+  - signs the inner Mach-O binary in place
+
+Limitations: nested bundles (`Frameworks/`, `PlugIns/`, `XPCServices/`, ...)
+inside another bundle are not signed recursively. Sign the inner bundles
+first, then sign the outer bundle.
+
 ## Example signature
 
 At a high level the embedded ad-hoc signature consists of three blobs in a superblob:

--- a/README.md
+++ b/README.md
@@ -82,9 +82,16 @@ directory (or a `Foo.framework/Versions/X` subpath). For bundles it:
   - hashes `CodeResources` into CodeDirectory special slot 3
   - signs the inner Mach-O binary in place
 
-Limitations: nested bundles (`Frameworks/`, `PlugIns/`, `XPCServices/`, ...)
-inside another bundle are not signed recursively. Sign the inner bundles
-first, then sign the outer bundle.
+Nested bundles directly under `Frameworks/`, `SharedFrameworks/`, `PlugIns/`,
+`Plug-ins/`, `XPCServices/`, or `Helpers/` are signed recursively (deepest
+first), and recorded in the outer `CodeResources` as `cdhash` entries with a
+`requirement` covering every Mach-O slice. Signing options (`-o runtime`,
+`--entitlements`, `--generate-entitlement-der`, `--preserve-metadata`) are
+propagated to nested signs; the nested bundle's own `CFBundleIdentifier` is
+used rather than inheriting from the outer.
+
+Non-bundle entries directly under those nested-bundle directories are not
+supported and will error.
 
 ## Example signature
 

--- a/bundle.cpp
+++ b/bundle.cpp
@@ -1,0 +1,192 @@
+#include "bundle.h"
+
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <plist/plist.h>
+
+namespace SigTool {
+
+namespace {
+
+bool isDir(const std::string& path) {
+    struct stat st{};
+    return stat(path.c_str(), &st) == 0 && S_ISDIR(st.st_mode);
+}
+
+bool isFile(const std::string& path) {
+    struct stat st{};
+    return stat(path.c_str(), &st) == 0 && S_ISREG(st.st_mode);
+}
+
+std::string trimSlash(std::string p) {
+    while (p.size() > 1 && p.back() == '/') p.pop_back();
+    return p;
+}
+
+std::string basename(const std::string& s) {
+    auto slash = s.find_last_of('/');
+    return slash == std::string::npos ? s : s.substr(slash + 1);
+}
+
+bool endsWith(const std::string& s, const std::string& suffix) {
+    return s.size() >= suffix.size()
+           && s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+std::string slurpFile(const std::string& path) {
+    std::ifstream in(path, std::ifstream::binary);
+    if (!in.is_open()) {
+        throw std::runtime_error{"opening '" + path + "': read failed"};
+    }
+    std::stringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+}
+
+// Parse an Info.plist (XML or binary) and return the top-level string
+// values for the requested keys (empty string if missing / not a string).
+std::vector<std::string> readPlistStrings(const std::string& path,
+                                          const std::vector<std::string>& keys) {
+    std::string data = slurpFile(path);
+    plist_t root = nullptr;
+    plist_err_t err = plist_from_memory(data.data(),
+                                        static_cast<uint32_t>(data.size()),
+                                        &root, nullptr);
+    if (err != PLIST_ERR_SUCCESS || !root) {
+        if (root) plist_free(root);
+        throw std::runtime_error{"failed to parse plist '" + path + "'"};
+    }
+    std::vector<std::string> out(keys.size());
+    if (plist_get_node_type(root) == PLIST_DICT) {
+        for (size_t i = 0; i < keys.size(); i++) {
+            plist_t v = plist_dict_get_item(root, keys[i].c_str());
+            if (v && plist_get_node_type(v) == PLIST_STRING) {
+                char* str = nullptr;
+                plist_get_string_val(v, &str);
+                if (str) {
+                    out[i] = str;
+                    plist_mem_free(str);
+                }
+            }
+        }
+    }
+    plist_free(root);
+    return out;
+}
+
+// Resolve a possibly-symlinked Versions/Current to a concrete version dir name.
+std::string resolveCurrentVersion(const std::string& versionsDir) {
+    std::string current = versionsDir + "/Current";
+    char buf[1024];
+    ssize_t n = ::readlink(current.c_str(), buf, sizeof(buf) - 1);
+    if (n > 0) {
+        buf[n] = '\0';
+        return std::string{buf};
+    }
+    // Fallback: pick "A".
+    if (isDir(versionsDir + "/A")) return "A";
+    throw std::runtime_error{"cannot resolve framework Versions/Current under " + versionsDir};
+}
+
+void populateFromInfoPlist(Bundle& b) {
+    if (b.infoPlistPath.empty() || !isFile(b.infoPlistPath)) return;
+    b.identifier = readPlistStrings(b.infoPlistPath, {"CFBundleIdentifier"})[0];
+}
+
+} // namespace
+
+Bundle detectBundle(const std::string& rawPath) {
+    Bundle b{};
+    std::string path = trimSlash(rawPath);
+    b.root = path;
+
+    if (isFile(path)) {
+        b.type = Bundle::Type::Single;
+        b.binaryPath = path;
+        return b;
+    }
+
+    if (!isDir(path)) {
+        throw std::runtime_error{"path does not exist: '" + rawPath + "'"};
+    }
+
+    // Framework: Foo.framework or Foo.framework/Versions/X
+    {
+        std::string fwRoot;
+        std::string version;
+        if (endsWith(path, ".framework")) {
+            fwRoot = path;
+            version = resolveCurrentVersion(fwRoot + "/Versions");
+        } else {
+            // Maybe Foo.framework/Versions/X
+            auto slash = path.find_last_of('/');
+            if (slash != std::string::npos) {
+                std::string parent = path.substr(0, slash);
+                if (endsWith(parent, "/Versions")) {
+                    std::string grand = parent.substr(0, parent.size() - 9);
+                    if (endsWith(grand, ".framework")) {
+                        fwRoot = grand;
+                        version = path.substr(slash + 1);
+                    }
+                }
+            }
+        }
+        if (!fwRoot.empty()) {
+            std::string fwName = basename(fwRoot);
+            fwName = fwName.substr(0, fwName.size() - sizeof(".framework") + 1);
+            b.type = Bundle::Type::Framework;
+            b.root = fwRoot;
+            b.contentsRoot = fwRoot + "/Versions/" + version;
+            b.binaryPath = b.contentsRoot + "/" + fwName;
+            std::string ip = b.contentsRoot + "/Resources/Info.plist";
+            if (isFile(ip)) b.infoPlistPath = ip;
+            populateFromInfoPlist(b);
+            if (!isFile(b.binaryPath)) {
+                throw std::runtime_error{
+                        "framework binary not found: '" + b.binaryPath + "'"};
+            }
+            return b;
+        }
+    }
+
+    // App / generic .app-style bundle: Foo.app
+    if (endsWith(path, ".app") || endsWith(path, ".bundle") || endsWith(path, ".xpc")) {
+        b.type = Bundle::Type::App;
+        b.root = path;
+        b.contentsRoot = path + "/Contents";
+        b.infoPlistPath = b.contentsRoot + "/Info.plist";
+        if (!isFile(b.infoPlistPath)) {
+            throw std::runtime_error{
+                    "bundle Info.plist not found at '" + b.infoPlistPath + "'"};
+        }
+        auto values = readPlistStrings(b.infoPlistPath,
+                                       {"CFBundleIdentifier", "CFBundleExecutable"});
+        b.identifier = values[0];
+        std::string execName = values[1];
+        if (execName.empty()) {
+            std::string base = basename(path);
+            for (const auto& suffix : {".app", ".bundle", ".xpc"}) {
+                if (endsWith(base, suffix)) {
+                    execName = base.substr(0, base.size() - std::string{suffix}.size());
+                    break;
+                }
+            }
+        }
+        b.binaryPath = b.contentsRoot + "/MacOS/" + execName;
+        if (!isFile(b.binaryPath)) {
+            throw std::runtime_error{
+                    "bundle executable not found: '" + b.binaryPath + "'"};
+        }
+        return b;
+    }
+
+    throw std::runtime_error{
+            "directory '" + rawPath + "' is not a recognised bundle "
+            "(*.framework, *.app, *.bundle, *.xpc)"};
+}
+
+};

--- a/bundle.h
+++ b/bundle.h
@@ -1,0 +1,41 @@
+#ifndef SIGTOOL_BUNDLE_H
+#define SIGTOOL_BUNDLE_H
+
+#include <string>
+
+namespace SigTool {
+
+struct Bundle {
+    enum class Type { Single, App, Framework };
+
+    Type type = Type::Single;
+
+    // Bundle root as the user passed it (or single-file path).
+    std::string root;
+
+    // Walk root for resource hashing:
+    //   App        -> <root>/Contents
+    //   Framework  -> <root>/Versions/<V>
+    //   Single     -> empty
+    std::string contentsRoot;
+
+    // Inner Mach-O binary (the only path actually signed).
+    std::string binaryPath;
+
+    // Info.plist path (empty for Single, or if the bundle has none).
+    std::string infoPlistPath;
+
+    // CFBundleIdentifier from Info.plist (empty if not derivable).
+    std::string identifier;
+};
+
+// Detect a bundle structure from a path. If `path` is a regular file, returns
+// a Single-typed Bundle with binaryPath=path. If it's a directory recognised
+// as a framework or .app, populates the bundle paths and reads the identifier
+// from Info.plist. Throws std::runtime_error on unsupported directories or
+// malformed bundles.
+Bundle detectBundle(const std::string& path);
+
+};
+
+#endif // SIGTOOL_BUNDLE_H

--- a/codesign.cpp
+++ b/codesign.cpp
@@ -1,7 +1,20 @@
 #include "commands.h"
 #include <CLI11.hpp>
+#include <cstring>
+#include <iostream>
+
+static int run(int argc, char **argv);
 
 int main(int argc, char **argv) {
+    try {
+        return run(argc, argv);
+    } catch (const std::exception &e) {
+        std::cerr << "codesign: error: " << e.what() << std::endl;
+        return 1;
+    }
+}
+
+static int run(int argc, char **argv) {
     CLI::App app{"codesign"};
 
     std::string identity, identifier, entitlements, timestamp, optionsFlags;

--- a/commands.cpp
+++ b/commands.cpp
@@ -9,8 +9,10 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#include "bundle.h"
 #include "commands.h"
 #include "macho.h"
+#include "resources.h"
 #include "signature.h"
 #include "der.h"
 
@@ -157,6 +159,18 @@ static SuperBlob signMachO(
     codeDirectory->setSpecialHash(requirements->slotType(), hashBlob(requirements));
     sb.blobs.push_back(requirements);
 
+    // bundle special hashes: slot 1 = Info.plist, slot 3 = CodeResources
+    if (!options.infoPlistPath.empty()) {
+        std::string infoData = readFile(options.infoPlistPath);
+        Hash infoHash{infoData.data(), infoData.size()};
+        codeDirectory->setSpecialHash(1 /* CSSLOT_INFOSLOT */, infoHash);
+    }
+    if (!options.codeResourcesPath.empty()) {
+        std::string crData = readFile(options.codeResourcesPath);
+        Hash crHash{crData.data(), crData.size()};
+        codeDirectory->setSpecialHash(3 /* CSSLOT_RESOURCEDIR */, crHash);
+    }
+
     // optional blob: entitlements
     if (!options.entitlements.empty()) {
         std::string plistXml = readFile(options.entitlements);
@@ -266,33 +280,34 @@ static std::string inferIdentifier(const std::string& filename) {
     return basename;
 }
 
-int Commands::codesign(const CodesignOptions &options, const std::string &filename) {
-    std::string identifier = options.identifier;
-    if (identifier.empty()) {
-        identifier = inferIdentifier(filename);
-    }
-    // Parse and discovery arguments
-    MachOList list{filename};
+// Sign a single Mach-O file in place (handles allocation via codesign_allocate
+// and injection of the new signature).
+static void signOneMachO(const Commands::CodesignOptions &options,
+                         const std::string &binaryFile,
+                         const std::string &identifier,
+                         const std::string &infoPlistPath,
+                         const std::string &codeResourcesPath) {
+    MachOList list{binaryFile};
     std::vector<std::string> arguments;
 
     arguments.emplace_back("codesign_allocate");
     arguments.emplace_back("-i");
-    arguments.emplace_back(filename);
-
+    arguments.emplace_back(binaryFile);
 
     for (const auto &macho : list.machos) {
         auto codeSignature = macho->getCodeSignatureLoadCommand();
         if (!options.force && codeSignature) {
             throw std::runtime_error{"file is already signed. pass -f to sign regardless."};
         }
-        auto sb = signMachO(SignOptions{
-                .filename = filename,
+        auto sb = signMachO(Commands::SignOptions{
+                .filename = binaryFile,
                 .identifier = identifier,
                 .entitlements = options.entitlements,
                 .generateEntitlementDER = options.generateEntitlementDER,
                 .hardenedRuntime = options.hardenedRuntime,
+                .infoPlistPath = infoPlistPath,
+                .codeResourcesPath = codeResourcesPath,
         }, macho);
-
 
         arguments.emplace_back("-A");
         arguments.emplace_back(std::to_string(macho->header.cpuType));
@@ -303,16 +318,14 @@ int Commands::codesign(const CodesignOptions &options, const std::string &filena
         arguments.push_back(std::to_string(len));
     }
 
-    // Make temporary name
-    std::unique_ptr<char, decltype(&std::free)> tempfileName { strdup((filename + "XXXXXX").c_str()), std::free };
+    std::unique_ptr<char, decltype(&std::free)> tempfileName{
+            strdup((binaryFile + "XXXXXX").c_str()), std::free};
     int tempfile = mkstemp(tempfileName.get());
 
-    // Preserve mode
     struct stat sourceFileStat{};
-    if (stat(filename.c_str(), &sourceFileStat) != 0) {
-        throw std::runtime_error{std::string{"stat of "} + filename + " failed: " + strerror(errno)};
+    if (stat(binaryFile.c_str(), &sourceFileStat) != 0) {
+        throw std::runtime_error{std::string{"stat of "} + binaryFile + " failed: " + strerror(errno)};
     }
-
     if (fchmod(tempfile, sourceFileStat.st_mode) != 0) {
         throw std::runtime_error{"chmod temporary file"};
     }
@@ -320,10 +333,8 @@ int Commands::codesign(const CodesignOptions &options, const std::string &filena
     arguments.emplace_back("-o");
     arguments.emplace_back(std::string(tempfileName.get()));
 
-    // codesign_allocate
     pid_t pid;
     char **spawnArgs = toSpawnArgs(arguments);
-
     const char *codesign_allocate = getenv("CODESIGN_ALLOCATE");
     if (!codesign_allocate) {
         codesign_allocate = "codesign_allocate";
@@ -332,7 +343,7 @@ int Commands::codesign(const CodesignOptions &options, const std::string &filena
     int spawn_result;
     if ((spawn_result = posix_spawnp(&pid, codesign_allocate, nullptr, nullptr, spawnArgs, environ)) != 0) {
         throw std::runtime_error{std::string{"Failed to spawn codesign_allocate: "} + strerror(spawn_result)};
-    };
+    }
 
     int codesign_status;
     pid_t waitpid_result;
@@ -355,20 +366,57 @@ int Commands::codesign(const CodesignOptions &options, const std::string &filena
         throw std::runtime_error{std::string{"close: "} + strerror(tempfile)};
     }
 
-    // inject
-    Commands::inject(SignOptions{
+    Commands::inject(Commands::SignOptions{
             .filename = std::string(tempfileName.get()),
             .identifier = identifier,
             .entitlements = options.entitlements,
             .generateEntitlementDER = options.generateEntitlementDER,
             .hardenedRuntime = options.hardenedRuntime,
+            .infoPlistPath = infoPlistPath,
+            .codeResourcesPath = codeResourcesPath,
     });
 
-    // rename temp file to output
-    if (rename(tempfileName.get(), filename.c_str()) != 0) {
+    if (rename(tempfileName.get(), binaryFile.c_str()) != 0) {
         throw std::runtime_error{"rename failed"};
     }
+}
 
+static void writeFileBytes(const std::string &path, const std::string &bytes) {
+    std::ofstream out(path, std::ofstream::binary | std::ofstream::trunc);
+    if (!out.is_open()) {
+        throw std::runtime_error{"opening '" + path + "' for write failed"};
+    }
+    out.write(bytes.data(), bytes.size());
+    if (!out) {
+        throw std::runtime_error{"writing to '" + path + "' failed"};
+    }
+}
+
+int Commands::codesign(const CodesignOptions &options, const std::string &filename) {
+    Bundle bundle = detectBundle(filename);
+
+    std::string identifier = options.identifier;
+    if (identifier.empty()) identifier = bundle.identifier;
+    if (identifier.empty()) identifier = inferIdentifier(bundle.binaryPath);
+
+    if (bundle.type == Bundle::Type::Single) {
+        signOneMachO(options, bundle.binaryPath, identifier, "", "");
+        return 0;
+    }
+
+    // Bundle: generate CodeResources, write to disk, then sign the binary
+    // with slot 1 (Info.plist) and slot 3 (CodeResources) populated.
+    std::string codeResources = generateCodeResources(bundle);
+    std::string sigDir = bundle.contentsRoot + "/_CodeSignature";
+    if (mkdir(sigDir.c_str(), 0755) != 0 && errno != EEXIST) {
+        throw std::runtime_error{
+                std::string{"mkdir '" + sigDir + "': "} + strerror(errno)};
+    }
+    std::string crPath = sigDir + "/CodeResources";
+    writeFileBytes(crPath, codeResources);
+
+    signOneMachO(options, bundle.binaryPath, identifier,
+                 bundle.infoPlistPath, crPath);
     return 0;
 }
 };

--- a/commands.cpp
+++ b/commands.cpp
@@ -265,6 +265,61 @@ static void freeArgs(char **spawnArgs, std::vector<std::string>::size_type size)
     free(spawnArgs);
 }
 
+// Compute the cdhash of every signed Mach-O slice in `filename` — the first
+// 20 bytes of SHA-256 over each slice's CodeDirectory blob. Throws if the
+// binary has no signature.
+static std::vector<std::vector<uint8_t>> computeCDHashes(const std::string& filename);
+
+static uint32_t readBE32(const char *p) {
+    auto u = reinterpret_cast<const unsigned char *>(p);
+    return (uint32_t(u[0]) << 24) | (uint32_t(u[1]) << 16)
+           | (uint32_t(u[2]) << 8) | uint32_t(u[3]);
+}
+
+static std::vector<std::vector<uint8_t>> computeCDHashes(const std::string& filename) {
+    std::vector<std::vector<uint8_t>> out;
+    MachOList list{filename};
+    for (const auto &macho : list.machos) {
+        auto cs = macho->getCodeSignatureLoadCommand();
+        if (!cs) continue;
+
+        std::ifstream in(filename, std::ifstream::binary);
+        if (!in.is_open()) continue;
+        in.seekg(macho->offset + cs->data.dataOff);
+        std::vector<char> buf(cs->data.dataSize);
+        in.read(buf.data(), buf.size());
+        if (static_cast<size_t>(in.gcount()) != buf.size()) continue;
+
+        if (buf.size() < 12) continue;
+        if (readBE32(buf.data()) != CSMAGIC_EMBEDDED_SIGNATURE) continue;
+        uint32_t count = readBE32(buf.data() + 8);
+        for (uint32_t i = 0; i < count; i++) {
+            size_t indexEntry = 12 + size_t{i} * 8;
+            if (indexEntry + 8 > buf.size()) break;
+            uint32_t blobOff = readBE32(buf.data() + indexEntry + 4);
+            if (blobOff + 8 > buf.size()) continue;
+            uint32_t blobMagic = readBE32(buf.data() + blobOff);
+            uint32_t blobLen = readBE32(buf.data() + blobOff + 4);
+            if (blobOff + blobLen > buf.size()) continue;
+            if (blobMagic == CSMAGIC_CODEDIRECTORY) {
+                SHA256Hash h{buf.data() + blobOff, blobLen};
+                std::vector<uint8_t> cdhash(20);
+                for (int b = 0; b < 20; b++) {
+                    cdhash[b] = static_cast<uint8_t>(h.bytes[b]);
+                }
+                out.push_back(std::move(cdhash));
+                break; // Each slice has one CodeDirectory.
+            }
+        }
+    }
+    if (out.empty()) {
+        throw std::runtime_error{
+                "computeCDHashes: no signed CodeDirectory found in '"
+                + filename + "'"};
+    }
+    return out;
+}
+
 static std::string inferIdentifier(const std::string& filename) {
     // basename / basename_r are awkward to use. We don't need the exact
     // meaning of basename.
@@ -404,9 +459,27 @@ int Commands::codesign(const CodesignOptions &options, const std::string &filena
         return 0;
     }
 
-    // Bundle: generate CodeResources, write to disk, then sign the binary
+    // Bundle: sign nested bundles deepest-first so we can capture their
+    // cdhashes for the outer CodeResources, then sign this bundle's binary
     // with slot 1 (Info.plist) and slot 3 (CodeResources) populated.
-    std::string codeResources = generateCodeResources(bundle);
+    std::vector<NestedCdHash> nestedHashes;
+    auto nestedRels = findNestedBundles(bundle);
+    for (const auto& rel : nestedRels) {
+        std::string nestedPath = bundle.contentsRoot + "/" + rel;
+        // Recurse with force=true (we're orchestrating a fresh sign of the
+        // whole bundle) and identifier cleared so the nested bundle uses its
+        // own CFBundleIdentifier rather than inheriting the outer's.
+        CodesignOptions nestedOpts = options;
+        nestedOpts.identifier.clear();
+        nestedOpts.force = true;
+        Commands::codesign(nestedOpts, nestedPath);
+
+        Bundle nestedBundle = detectBundle(nestedPath);
+        nestedHashes.push_back(
+                NestedCdHash{rel, computeCDHashes(nestedBundle.binaryPath)});
+    }
+
+    std::string codeResources = generateCodeResources(bundle, nestedHashes);
     std::string sigDir = bundle.contentsRoot + "/_CodeSignature";
     if (mkdir(sigDir.c_str(), 0755) != 0 && errno != EEXIST) {
         throw std::runtime_error{

--- a/commands.h
+++ b/commands.h
@@ -11,6 +11,10 @@ namespace Commands {
         std::string entitlements;
         bool generateEntitlementDER;
         bool hardenedRuntime;
+        // For bundle signing: paths whose hashes seed CodeDirectory special
+        // slots 1 (Info.plist) and 3 (CodeResources). Empty = unused.
+        std::string infoPlistPath;
+        std::string codeResourcesPath;
     };
 
     struct CodesignOptions {

--- a/hash.cpp
+++ b/hash.cpp
@@ -15,4 +15,37 @@ SHA256Hash::SHA256Hash(const std::string& str)
 SHA256Hash::SHA256Hash(const unsigned char *data, size_t len) {
     SHA256(data, len, reinterpret_cast<unsigned char *>(&this->bytes[0]));
 }
+
+SHA1Hash::SHA1Hash(const char *data, size_t len) {
+    SHA1(reinterpret_cast<const unsigned char *>(data), len,
+         reinterpret_cast<unsigned char *>(&this->bytes[0]));
+}
+
+SHA1Hash::SHA1Hash(const std::string &str) : SHA1Hash(str.data(), str.length()) {}
+
+static const char *kBase64 =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+std::string base64Encode(const char *data, size_t len) {
+    std::string out;
+    out.reserve(((len + 2) / 3) * 4);
+    auto u = reinterpret_cast<const unsigned char *>(data);
+    size_t i = 0;
+    for (; i + 3 <= len; i += 3) {
+        uint32_t v = (uint32_t(u[i]) << 16) | (uint32_t(u[i + 1]) << 8) | uint32_t(u[i + 2]);
+        out.push_back(kBase64[(v >> 18) & 0x3f]);
+        out.push_back(kBase64[(v >> 12) & 0x3f]);
+        out.push_back(kBase64[(v >> 6) & 0x3f]);
+        out.push_back(kBase64[v & 0x3f]);
+    }
+    if (i < len) {
+        uint32_t v = uint32_t(u[i]) << 16;
+        if (i + 1 < len) v |= uint32_t(u[i + 1]) << 8;
+        out.push_back(kBase64[(v >> 18) & 0x3f]);
+        out.push_back(kBase64[(v >> 12) & 0x3f]);
+        out.push_back(i + 1 < len ? kBase64[(v >> 6) & 0x3f] : '=');
+        out.push_back('=');
+    }
+    return out;
+}
 };

--- a/hash.h
+++ b/hash.h
@@ -19,6 +19,18 @@ struct SHA256Hash {
     SHA256Hash(): bytes{} {};
 };
 
+struct SHA1Hash {
+    static const int constexpr hashSize = 20;
+    char bytes[hashSize]{};
+
+    SHA1Hash(const char *data, size_t len);
+    explicit SHA1Hash(const std::string &str);
+
+    SHA1Hash(): bytes{} {};
+};
+
+std::string base64Encode(const char *data, size_t len);
+
 using Hash = SHA256Hash;
 };
 

--- a/macho.cpp
+++ b/macho.cpp
@@ -1,4 +1,5 @@
 #include <cstring>
+#include <sstream>
 #include <sys/stat.h>
 #include "macho.h"
 
@@ -10,7 +11,64 @@ constexpr const uint32_t MH_CIGAM_64 = 0xCFFAEDFE;
 constexpr const uint32_t MH_FAT_MAGIC = 0xCAFEBABE;
 constexpr const uint32_t MH_FAT_CIGAM = 0xBEBAFECA;
 
+// If `path` looks like a bundle directory (e.g. Foo.framework/Versions/A or
+// Foo.app), return the conventional path of the main Mach-O binary inside.
+// Returns an empty string if no convention applies.
+static std::string suggestBundleBinary(const std::string &path) {
+    std::string p = path;
+    while (p.size() > 1 && p.back() == '/') p.pop_back();
+
+    auto basename = [](const std::string &s) {
+        auto slash = s.find_last_of('/');
+        return slash == std::string::npos ? s : s.substr(slash + 1);
+    };
+    auto endsWith = [](const std::string &s, const std::string &suffix) {
+        return s.size() >= suffix.size()
+               && s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
+    };
+
+    // Foo.framework/Versions/<V>
+    auto slash = p.find_last_of('/');
+    if (slash != std::string::npos) {
+        std::string parent = p.substr(0, slash);
+        auto slash2 = parent.find_last_of('/');
+        std::string grandparent = slash2 == std::string::npos
+                                  ? std::string{}
+                                  : parent.substr(0, slash2);
+        std::string parentBase = slash2 == std::string::npos
+                                 ? parent
+                                 : parent.substr(slash2 + 1);
+        if (parentBase == "Versions" && endsWith(grandparent, ".framework")) {
+            std::string name = basename(grandparent);
+            name = name.substr(0, name.size() - sizeof(".framework") + 1);
+            return p + "/" + name;
+        }
+    }
+
+    // Foo.app
+    if (endsWith(p, ".app")) {
+        std::string name = basename(p);
+        name = name.substr(0, name.size() - sizeof(".app") + 1);
+        return p + "/Contents/MacOS/" + name;
+    }
+
+    return {};
+}
+
 MachOList::MachOList(const std::string &filename) {
+    struct stat st{};
+    if (stat(filename.c_str(), &st) == 0 && S_ISDIR(st.st_mode)) {
+        std::ostringstream msg;
+        msg << "input is a directory: '" << filename
+            << "'. Bundle signing (resource manifest generation) is not "
+               "supported; pass the path to the Mach-O binary inside";
+        std::string suggestion = suggestBundleBinary(filename);
+        if (!suggestion.empty()) {
+            msg << ", e.g. '" << suggestion << "'";
+        }
+        throw NotAMachOFileException{msg.str()};
+    }
+
     std::ifstream f;
     f.open(filename, std::ifstream::in | std::ifstream::binary);
     if (f.fail()) {
@@ -20,7 +78,10 @@ MachOList::MachOList(const std::string &filename) {
     auto magic = Read::readBytes<uint32_t>(f);
 
     if (magic != MH_MAGIC_64 && magic != MH_CIGAM_64 && magic != MH_FAT_MAGIC && magic != MH_FAT_CIGAM) {
-        throw NotAMachOFileException{magic};
+        std::ostringstream msg;
+        msg << "not a Mach-O file: '" << filename << "' (unrecognized magic 0x"
+            << std::hex << magic << ")";
+        throw NotAMachOFileException{msg.str()};
     }
 
     if (magic == MH_FAT_CIGAM) {
@@ -60,7 +121,10 @@ MachO::MachO(std::ifstream &f, off_t offset, size_t size) : header{}, offset{off
     auto magic = Read::readBytes<uint32_t>(f);
 
     if (magic != MH_MAGIC_64 && magic != MH_CIGAM_64) {
-        throw NotAMachOFileException{magic};
+        std::ostringstream msg;
+        msg << "not a 64-bit Mach-O slice (unrecognized magic 0x"
+            << std::hex << magic << ")";
+        throw NotAMachOFileException{msg.str()};
     }
 
     f.read(reinterpret_cast<char *>(&header), sizeof(header));

--- a/macho.h
+++ b/macho.h
@@ -163,9 +163,14 @@ struct MachOList {
 };
 
 struct NotAMachOFileException : public std::exception {
-    uint32_t magic;
+    std::string message;
 
-    explicit NotAMachOFileException(uint32_t magic) : magic{magic} {}
+    explicit NotAMachOFileException(std::string message)
+            : message{std::move(message)} {}
+
+    const char *what() const noexcept override {
+        return message.c_str();
+    }
 };
 };
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,7 +1,19 @@
 #include "commands.h"
 #include <CLI11.hpp>
+#include <iostream>
+
+static int run(int argc, char **argv);
 
 int main(int argc, char **argv) {
+    try {
+        return run(argc, argv);
+    } catch (const std::exception &e) {
+        std::cerr << "sigtool: error: " << e.what() << std::endl;
+        return 1;
+    }
+}
+
+static int run(int argc, char **argv) {
     CLI::App app{"sigtool"};
     app.require_subcommand();
 

--- a/resources.cpp
+++ b/resources.cpp
@@ -1,0 +1,291 @@
+#include "resources.h"
+
+#include <algorithm>
+#include <cstring>
+#include <dirent.h>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <sys/stat.h>
+
+#include "hash.h"
+
+namespace SigTool {
+
+namespace {
+
+bool isFile(const std::string& path) {
+    struct stat st{};
+    return stat(path.c_str(), &st) == 0 && S_ISREG(st.st_mode);
+}
+
+std::string slurpFile(const std::string& path) {
+    std::ifstream in(path, std::ifstream::binary);
+    if (!in.is_open()) {
+        throw std::runtime_error{"opening '" + path + "': read failed"};
+    }
+    std::stringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+}
+
+bool isNestedBundleDirEntry(const std::string& relDir) {
+    static const char* nestedRoots[] = {
+            "Frameworks", "SharedFrameworks", "PlugIns", "Plug-ins",
+            "XPCServices", "Helpers"};
+    for (auto* r : nestedRoots) {
+        if (relDir == r) return true;
+    }
+    return false;
+}
+
+// Walk `dir` recursively, emitting every regular file's path RELATIVE to
+// `walkRoot`. Skips symlinks, directories, _CodeSignature/, and per-relative
+// path filters provided by the caller.
+void walk(const std::string& walkRoot, const std::string& subdir,
+          std::vector<std::string>& out) {
+    std::string fullDir = subdir.empty() ? walkRoot : (walkRoot + "/" + subdir);
+    DIR* d = opendir(fullDir.c_str());
+    if (!d) return;
+    std::vector<std::string> entries;
+    while (auto* ent = readdir(d)) {
+        std::string n = ent->d_name;
+        if (n == "." || n == "..") continue;
+        entries.push_back(n);
+    }
+    closedir(d);
+    std::sort(entries.begin(), entries.end());
+
+    for (const auto& n : entries) {
+        std::string rel = subdir.empty() ? n : (subdir + "/" + n);
+        std::string full = walkRoot + "/" + rel;
+        struct stat st{};
+        if (lstat(full.c_str(), &st) != 0) continue;
+        if (S_ISLNK(st.st_mode)) continue;
+        if (S_ISDIR(st.st_mode)) {
+            if (rel == "_CodeSignature") continue;
+            if (isNestedBundleDirEntry(rel)) {
+                throw std::runtime_error{
+                        "nested bundle directory '" + rel + "' under "
+                        + walkRoot + " is not supported. Sign nested bundles "
+                                     "first, then sign the outer bundle."};
+            }
+            walk(walkRoot, rel, out);
+            continue;
+        }
+        if (S_ISREG(st.st_mode)) {
+            out.push_back(rel);
+        }
+    }
+}
+
+bool isOmitted(const std::string& rel, const std::string& binaryRel,
+               bool omitRootInfoPlist) {
+    if (rel == binaryRel) return true;
+    // Anywhere
+    if (rel == ".DS_Store") return true;
+    auto slash = rel.find_last_of('/');
+    if (slash != std::string::npos && rel.substr(slash + 1) == ".DS_Store") return true;
+    // Root-only files for app bundles
+    if (omitRootInfoPlist) {
+        if (rel == "Info.plist") return true;
+        if (rel == "PkgInfo") return true;
+    }
+    // locversion.plist inside .lproj is omitted by Apple
+    if (rel.size() > 18
+        && rel.compare(rel.size() - 18, 18, "/locversion.plist") == 0) {
+        // confirm a .lproj segment precedes it
+        if (rel.find(".lproj/") != std::string::npos) return true;
+    }
+    return false;
+}
+
+void appendXmlEscaped(std::string& out, const std::string& s) {
+    for (char c : s) {
+        switch (c) {
+            case '&': out += "&amp;"; break;
+            case '<': out += "&lt;"; break;
+            case '>': out += "&gt;"; break;
+            default: out += c;
+        }
+    }
+}
+
+// rules / rules2 sections, baked in to match Apple's defaults verbatim.
+const char* kRulesSection =
+        "\t<key>rules</key>\n"
+        "\t<dict>\n"
+        "\t\t<key>^Resources/</key>\n"
+        "\t\t<true/>\n"
+        "\t\t<key>^Resources/.*\\.lproj/</key>\n"
+        "\t\t<dict>\n"
+        "\t\t\t<key>optional</key>\n"
+        "\t\t\t<true/>\n"
+        "\t\t\t<key>weight</key>\n"
+        "\t\t\t<real>1000</real>\n"
+        "\t\t</dict>\n"
+        "\t\t<key>^Resources/.*\\.lproj/locversion.plist$</key>\n"
+        "\t\t<dict>\n"
+        "\t\t\t<key>omit</key>\n"
+        "\t\t\t<true/>\n"
+        "\t\t\t<key>weight</key>\n"
+        "\t\t\t<real>1100</real>\n"
+        "\t\t</dict>\n"
+        "\t\t<key>^Resources/Base\\.lproj/</key>\n"
+        "\t\t<dict>\n"
+        "\t\t\t<key>weight</key>\n"
+        "\t\t\t<real>1010</real>\n"
+        "\t\t</dict>\n"
+        "\t\t<key>^version.plist$</key>\n"
+        "\t\t<true/>\n"
+        "\t</dict>\n"
+        "\t<key>rules2</key>\n"
+        "\t<dict>\n"
+        "\t\t<key>.*\\.dSYM($|/)</key>\n"
+        "\t\t<dict>\n"
+        "\t\t\t<key>weight</key>\n"
+        "\t\t\t<real>11</real>\n"
+        "\t\t</dict>\n"
+        "\t\t<key>^(.*/)?\\.DS_Store$</key>\n"
+        "\t\t<dict>\n"
+        "\t\t\t<key>omit</key>\n"
+        "\t\t\t<true/>\n"
+        "\t\t\t<key>weight</key>\n"
+        "\t\t\t<real>2000</real>\n"
+        "\t\t</dict>\n"
+        "\t\t<key>^(Frameworks|SharedFrameworks|PlugIns|Plug-ins|XPCServices|Helpers|MacOS|Library/(Automator|Spotlight|LoginItems))/</key>\n"
+        "\t\t<dict>\n"
+        "\t\t\t<key>nested</key>\n"
+        "\t\t\t<true/>\n"
+        "\t\t\t<key>weight</key>\n"
+        "\t\t\t<real>10</real>\n"
+        "\t\t</dict>\n"
+        "\t\t<key>^.*</key>\n"
+        "\t\t<true/>\n"
+        "\t\t<key>^Info\\.plist$</key>\n"
+        "\t\t<dict>\n"
+        "\t\t\t<key>omit</key>\n"
+        "\t\t\t<true/>\n"
+        "\t\t\t<key>weight</key>\n"
+        "\t\t\t<real>20</real>\n"
+        "\t\t</dict>\n"
+        "\t\t<key>^PkgInfo$</key>\n"
+        "\t\t<dict>\n"
+        "\t\t\t<key>omit</key>\n"
+        "\t\t\t<true/>\n"
+        "\t\t\t<key>weight</key>\n"
+        "\t\t\t<real>20</real>\n"
+        "\t\t</dict>\n"
+        "\t\t<key>^Resources/</key>\n"
+        "\t\t<dict>\n"
+        "\t\t\t<key>weight</key>\n"
+        "\t\t\t<real>20</real>\n"
+        "\t\t</dict>\n"
+        "\t\t<key>^Resources/.*\\.lproj/</key>\n"
+        "\t\t<dict>\n"
+        "\t\t\t<key>optional</key>\n"
+        "\t\t\t<true/>\n"
+        "\t\t\t<key>weight</key>\n"
+        "\t\t\t<real>1000</real>\n"
+        "\t\t</dict>\n"
+        "\t\t<key>^Resources/.*\\.lproj/locversion.plist$</key>\n"
+        "\t\t<dict>\n"
+        "\t\t\t<key>omit</key>\n"
+        "\t\t\t<true/>\n"
+        "\t\t\t<key>weight</key>\n"
+        "\t\t\t<real>1100</real>\n"
+        "\t\t</dict>\n"
+        "\t\t<key>^Resources/Base\\.lproj/</key>\n"
+        "\t\t<dict>\n"
+        "\t\t\t<key>weight</key>\n"
+        "\t\t\t<real>1010</real>\n"
+        "\t\t</dict>\n"
+        "\t\t<key>^[^/]+$</key>\n"
+        "\t\t<dict>\n"
+        "\t\t\t<key>nested</key>\n"
+        "\t\t\t<true/>\n"
+        "\t\t\t<key>weight</key>\n"
+        "\t\t\t<real>10</real>\n"
+        "\t\t</dict>\n"
+        "\t\t<key>^embedded\\.provisionprofile$</key>\n"
+        "\t\t<dict>\n"
+        "\t\t\t<key>weight</key>\n"
+        "\t\t\t<real>20</real>\n"
+        "\t\t</dict>\n"
+        "\t\t<key>^version\\.plist$</key>\n"
+        "\t\t<dict>\n"
+        "\t\t\t<key>weight</key>\n"
+        "\t\t\t<real>20</real>\n"
+        "\t\t</dict>\n"
+        "\t</dict>\n";
+
+} // namespace
+
+std::string generateCodeResources(const Bundle& bundle) {
+    if (bundle.type == Bundle::Type::Single) {
+        throw std::runtime_error{"generateCodeResources called on Single bundle"};
+    }
+    if (bundle.contentsRoot.empty()) {
+        throw std::runtime_error{"bundle has no contentsRoot"};
+    }
+
+    // Compute the binary's path RELATIVE to contentsRoot.
+    std::string binaryRel;
+    if (bundle.binaryPath.size() > bundle.contentsRoot.size() + 1
+        && bundle.binaryPath.compare(0, bundle.contentsRoot.size(), bundle.contentsRoot) == 0
+        && bundle.binaryPath[bundle.contentsRoot.size()] == '/') {
+        binaryRel = bundle.binaryPath.substr(bundle.contentsRoot.size() + 1);
+    }
+
+    bool omitRootInfoPlist = (bundle.type == Bundle::Type::App);
+
+    std::vector<std::string> files;
+    walk(bundle.contentsRoot, "", files);
+
+    // Filter and sort.
+    std::vector<std::string> kept;
+    kept.reserve(files.size());
+    for (const auto& rel : files) {
+        if (isOmitted(rel, binaryRel, omitRootInfoPlist)) continue;
+        kept.push_back(rel);
+    }
+    std::sort(kept.begin(), kept.end());
+
+    std::string out;
+    out += "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+           "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" "
+           "\"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
+           "<plist version=\"1.0\">\n"
+           "<dict>\n";
+
+    out += "\t<key>files</key>\n\t<dict>\n";
+    for (const auto& rel : kept) {
+        std::string contents = slurpFile(bundle.contentsRoot + "/" + rel);
+        SHA1Hash h{contents.data(), contents.size()};
+        out += "\t\t<key>";
+        appendXmlEscaped(out, rel);
+        out += "</key>\n\t\t<data>\n\t\t";
+        out += base64Encode(h.bytes, sizeof(h.bytes));
+        out += "\n\t\t</data>\n";
+    }
+    out += "\t</dict>\n";
+
+    out += "\t<key>files2</key>\n\t<dict>\n";
+    for (const auto& rel : kept) {
+        std::string contents = slurpFile(bundle.contentsRoot + "/" + rel);
+        SHA256Hash h{contents.data(), contents.size()};
+        out += "\t\t<key>";
+        appendXmlEscaped(out, rel);
+        out += "</key>\n\t\t<dict>\n\t\t\t<key>hash2</key>\n\t\t\t<data>\n\t\t\t";
+        out += base64Encode(h.bytes, sizeof(h.bytes));
+        out += "\n\t\t\t</data>\n\t\t</dict>\n";
+    }
+    out += "\t</dict>\n";
+
+    out += kRulesSection;
+    out += "</dict>\n</plist>\n";
+
+    return out;
+}
+
+};

--- a/resources.cpp
+++ b/resources.cpp
@@ -40,8 +40,9 @@ bool isNestedBundleDirEntry(const std::string& relDir) {
 }
 
 // Walk `dir` recursively, emitting every regular file's path RELATIVE to
-// `walkRoot`. Skips symlinks, directories, _CodeSignature/, and per-relative
-// path filters provided by the caller.
+// `walkRoot`. Skips symlinks, directories, _CodeSignature/, and the immediate
+// children of nested-bundle directories (those are signed separately and
+// recorded as cdhash entries).
 void walk(const std::string& walkRoot, const std::string& subdir,
           std::vector<std::string>& out) {
     std::string fullDir = subdir.empty() ? walkRoot : (walkRoot + "/" + subdir);
@@ -64,12 +65,10 @@ void walk(const std::string& walkRoot, const std::string& subdir,
         if (S_ISLNK(st.st_mode)) continue;
         if (S_ISDIR(st.st_mode)) {
             if (rel == "_CodeSignature") continue;
-            if (isNestedBundleDirEntry(rel)) {
-                throw std::runtime_error{
-                        "nested bundle directory '" + rel + "' under "
-                        + walkRoot + " is not supported. Sign nested bundles "
-                                     "first, then sign the outer bundle."};
-            }
+            // Nested-bundle dirs are skipped here; their immediate children
+            // are returned by findNestedBundles() and emitted as cdhash
+            // entries instead of file hashes.
+            if (subdir.empty() && isNestedBundleDirEntry(rel)) continue;
             walk(walkRoot, rel, out);
             continue;
         }
@@ -77,6 +76,16 @@ void walk(const std::string& walkRoot, const std::string& subdir,
             out.push_back(rel);
         }
     }
+}
+
+bool looksLikeBundleSuffix(const std::string& name) {
+    static const char* suffixes[] = {".framework", ".app", ".xpc", ".bundle"};
+    for (auto* s : suffixes) {
+        size_t sl = std::string{s}.size();
+        if (name.size() > sl
+            && name.compare(name.size() - sl, sl, s) == 0) return true;
+    }
+    return false;
 }
 
 bool isOmitted(const std::string& rel, const std::string& binaryRel,
@@ -221,7 +230,47 @@ const char* kRulesSection =
 
 } // namespace
 
-std::string generateCodeResources(const Bundle& bundle) {
+std::vector<std::string> findNestedBundles(const Bundle& bundle) {
+    std::vector<std::string> out;
+    if (bundle.contentsRoot.empty()) return out;
+
+    static const char* nestedRoots[] = {
+            "Frameworks", "SharedFrameworks", "PlugIns", "Plug-ins",
+            "XPCServices", "Helpers"};
+    for (auto* root : nestedRoots) {
+        std::string dirPath = bundle.contentsRoot + "/" + root;
+        DIR* d = opendir(dirPath.c_str());
+        if (!d) continue;
+        std::vector<std::string> children;
+        while (auto* ent = readdir(d)) {
+            std::string n = ent->d_name;
+            if (n == "." || n == "..") continue;
+            children.push_back(n);
+        }
+        closedir(d);
+        std::sort(children.begin(), children.end());
+
+        for (const auto& n : children) {
+            std::string full = dirPath + "/" + n;
+            struct stat st{};
+            if (lstat(full.c_str(), &st) != 0) continue;
+            if (S_ISLNK(st.st_mode)) continue;
+            if (!S_ISDIR(st.st_mode)) continue;
+            if (!looksLikeBundleSuffix(n)) {
+                throw std::runtime_error{
+                        "non-bundle entry '" + std::string{root} + "/" + n
+                        + "' under " + bundle.contentsRoot
+                        + " is not supported (expected *.framework, *.app, "
+                          "*.xpc, or *.bundle)"};
+            }
+            out.push_back(std::string{root} + "/" + n);
+        }
+    }
+    return out;
+}
+
+std::string generateCodeResources(const Bundle& bundle,
+                                  const std::vector<NestedCdHash>& nested) {
     if (bundle.type == Bundle::Type::Single) {
         throw std::runtime_error{"generateCodeResources called on Single bundle"};
     }
@@ -251,6 +300,13 @@ std::string generateCodeResources(const Bundle& bundle) {
     }
     std::sort(kept.begin(), kept.end());
 
+    // Sort nested entries by relativePath for stable output.
+    std::vector<NestedCdHash> nestedSorted = nested;
+    std::sort(nestedSorted.begin(), nestedSorted.end(),
+              [](const NestedCdHash& a, const NestedCdHash& b) {
+                  return a.relativePath < b.relativePath;
+              });
+
     std::string out;
     out += "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
            "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" "
@@ -258,6 +314,7 @@ std::string generateCodeResources(const Bundle& bundle) {
            "<plist version=\"1.0\">\n"
            "<dict>\n";
 
+    // SHA-1 dict — regular files only; nested bundles are NOT listed here.
     out += "\t<key>files</key>\n\t<dict>\n";
     for (const auto& rel : kept) {
         std::string contents = slurpFile(bundle.contentsRoot + "/" + rel);
@@ -270,15 +327,54 @@ std::string generateCodeResources(const Bundle& bundle) {
     }
     out += "\t</dict>\n";
 
+    // SHA-256 dict — regular files (hash2) plus nested bundles (cdhash).
+    // Apple sorts entries lexicographically by key; we interleave by merge.
     out += "\t<key>files2</key>\n\t<dict>\n";
-    for (const auto& rel : kept) {
-        std::string contents = slurpFile(bundle.contentsRoot + "/" + rel);
-        SHA256Hash h{contents.data(), contents.size()};
-        out += "\t\t<key>";
-        appendXmlEscaped(out, rel);
-        out += "</key>\n\t\t<dict>\n\t\t\t<key>hash2</key>\n\t\t\t<data>\n\t\t\t";
-        out += base64Encode(h.bytes, sizeof(h.bytes));
-        out += "\n\t\t\t</data>\n\t\t</dict>\n";
+    size_t ki = 0, ni = 0;
+    while (ki < kept.size() || ni < nestedSorted.size()) {
+        bool takeNested;
+        if (ki >= kept.size()) takeNested = true;
+        else if (ni >= nestedSorted.size()) takeNested = false;
+        else takeNested = (nestedSorted[ni].relativePath < kept[ki]);
+
+        if (takeNested) {
+            const auto& n = nestedSorted[ni++];
+            if (n.cdhashes.empty()) {
+                throw std::runtime_error{
+                        "nested bundle '" + n.relativePath + "' has no cdhash"};
+            }
+            out += "\t\t<key>";
+            appendXmlEscaped(out, n.relativePath);
+            out += "</key>\n\t\t<dict>\n\t\t\t<key>cdhash</key>\n"
+                   "\t\t\t<data>\n\t\t\t";
+            out += base64Encode(reinterpret_cast<const char*>(n.cdhashes[0].data()),
+                                n.cdhashes[0].size());
+            out += "\n\t\t\t</data>\n";
+            // `requirement` is authoritative for verify, and lets fat binaries
+            // be validated regardless of which slice the host loads. Emit one
+            // OR'd requirement covering every slice's cdhash.
+            out += "\t\t\t<key>requirement</key>\n\t\t\t<string>";
+            for (size_t i = 0; i < n.cdhashes.size(); i++) {
+                if (i > 0) out += " or ";
+                out += "cdhash H\"";
+                static const char* hex = "0123456789abcdef";
+                for (auto b : n.cdhashes[i]) {
+                    out += hex[(b >> 4) & 0xf];
+                    out += hex[b & 0xf];
+                }
+                out += "\"";
+            }
+            out += "</string>\n\t\t</dict>\n";
+        } else {
+            const auto& rel = kept[ki++];
+            std::string contents = slurpFile(bundle.contentsRoot + "/" + rel);
+            SHA256Hash h{contents.data(), contents.size()};
+            out += "\t\t<key>";
+            appendXmlEscaped(out, rel);
+            out += "</key>\n\t\t<dict>\n\t\t\t<key>hash2</key>\n\t\t\t<data>\n\t\t\t";
+            out += base64Encode(h.bytes, sizeof(h.bytes));
+            out += "\n\t\t\t</data>\n\t\t</dict>\n";
+        }
     }
     out += "\t</dict>\n";
 

--- a/resources.cpp
+++ b/resources.cpp
@@ -255,15 +255,21 @@ std::vector<std::string> findNestedBundles(const Bundle& bundle) {
             struct stat st{};
             if (lstat(full.c_str(), &st) != 0) continue;
             if (S_ISLNK(st.st_mode)) continue;
-            if (!S_ISDIR(st.st_mode)) continue;
-            if (!looksLikeBundleSuffix(n)) {
-                throw std::runtime_error{
-                        "non-bundle entry '" + std::string{root} + "/" + n
-                        + "' under " + bundle.contentsRoot
-                        + " is not supported (expected *.framework, *.app, "
-                          "*.xpc, or *.bundle)"};
+            // Bundle directories (recursively signed) and regular files
+            // (signed as a single Mach-O) are both treated as nested entries
+            // — they'll appear in CodeResources as cdhash entries.
+            if (S_ISDIR(st.st_mode)) {
+                if (!looksLikeBundleSuffix(n)) {
+                    throw std::runtime_error{
+                            "non-bundle directory '" + std::string{root} + "/"
+                            + n + "' under " + bundle.contentsRoot
+                            + " is not supported (expected *.framework, "
+                              "*.app, *.xpc, or *.bundle)"};
+                }
+                out.push_back(std::string{root} + "/" + n);
+            } else if (S_ISREG(st.st_mode)) {
+                out.push_back(std::string{root} + "/" + n);
             }
-            out.push_back(std::string{root} + "/" + n);
         }
     }
     return out;

--- a/resources.h
+++ b/resources.h
@@ -1,22 +1,35 @@
 #ifndef SIGTOOL_RESOURCES_H
 #define SIGTOOL_RESOURCES_H
 
+#include <cstdint>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "bundle.h"
 
 namespace SigTool {
 
-// Generate a CodeResources XML plist for the given bundle. Walks `contentsRoot`
-// recursively, hashes regular files (skipping the executable, _CodeSignature/,
-// Info.plist at the bundle's contentsRoot, .DS_Store, etc.), and emits the
-// `files`, `files2`, `rules`, and `rules2` sections matching Apple's defaults.
-//
-// Throws std::runtime_error if the bundle is Single (not a bundle), if the
-// contentsRoot is missing, or if a nested bundle is found at a known nested
-// location (Frameworks/, PlugIns/, ...) since this implementation does not
-// recurse into nested bundles.
-std::string generateCodeResources(const Bundle& bundle);
+// One nested-bundle entry: relative path from the bundle's contentsRoot
+// (e.g. "XPCServices/Inst.xpc") plus the inner binary's cdhashes — one per
+// Mach-O slice (thin = 1 entry, fat = 1 per slice). Each cdhash is the first
+// 20 bytes of SHA-256 over that slice's CodeDirectory blob.
+struct NestedCdHash {
+    std::string relativePath;
+    std::vector<std::vector<uint8_t>> cdhashes;
+};
+
+// Discover nested bundles directly under known nested-bundle directories
+// (Frameworks/, SharedFrameworks/, PlugIns/, Plug-ins/, XPCServices/,
+// Helpers/) under the given bundle's contentsRoot. Returns relative paths
+// suitable for both signing-each-nested and emitting cdhash entries later.
+std::vector<std::string> findNestedBundles(const Bundle& bundle);
+
+// Generate a CodeResources XML plist for the given bundle. Hashes regular
+// files; emits cdhash entries (in files2 only) for each nested bundle
+// supplied in `nested`.
+std::string generateCodeResources(const Bundle& bundle,
+                                  const std::vector<NestedCdHash>& nested);
 
 };
 

--- a/resources.h
+++ b/resources.h
@@ -1,0 +1,23 @@
+#ifndef SIGTOOL_RESOURCES_H
+#define SIGTOOL_RESOURCES_H
+
+#include <string>
+
+#include "bundle.h"
+
+namespace SigTool {
+
+// Generate a CodeResources XML plist for the given bundle. Walks `contentsRoot`
+// recursively, hashes regular files (skipping the executable, _CodeSignature/,
+// Info.plist at the bundle's contentsRoot, .DS_Store, etc.), and emits the
+// `files`, `files2`, `rules`, and `rules2` sections matching Apple's defaults.
+//
+// Throws std::runtime_error if the bundle is Single (not a bundle), if the
+// contentsRoot is missing, or if a nested bundle is found at a known nested
+// location (Frameworks/, PlugIns/, ...) since this implementation does not
+// recurse into nested bundles.
+std::string generateCodeResources(const Bundle& bundle);
+
+};
+
+#endif // SIGTOOL_RESOURCES_H


### PR DESCRIPTION
We need to sign bundles rather than just single macho binaries. There's nothing fancy in this implementation - we're trying to replicate what the upstream is doing with regards to recursive signing and producing the rules sections.