### PR TITLE
Support --preserve-metadata=identifier,entitlements,flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Options:
   --generate-entitlement-der  Also embed DER-encoded entitlements
   --timestamp[=none]          Accepted for compatibility; only =none is supported
   -o,--options TEXT           Comma-separated signing options (only "runtime" supported)
+  --preserve-metadata TEXT    Comma-separated list of fields to reuse from the existing
+                              signature (supported: identifier, entitlements, flags)
 ```
 
 `--timestamp=none` is accepted as a no-op so build tools that pass it can call
@@ -91,6 +93,22 @@ propagated to nested signs; the nested bundle's own `CFBundleIdentifier` is
 used rather than inheriting from the outer.
 
 Non-bundle entries directly under those nested-bundle directories are not
+supported and will error.
+
+### Preserving existing metadata
+
+`--preserve-metadata=identifier,entitlements,flags` re-signs a binary while
+reusing fields from its existing signature. Supported keys:
+
+  - `identifier` — reuse the existing CodeDirectory identifier (CLI `-i` still
+    wins if both are passed)
+  - `entitlements` — reuse the existing XML entitlements blob
+  - `flags` — preserve `CS_RUNTIME` (and its associated runtime SDK version)
+    from the original signature; other flag bits are not propagated
+
+The binary must already be signed; otherwise `codesign` errors. Other
+`--preserve-metadata` keys (`requirements`, `team-identifier`, `runtime`,
+`resource-rules`, `digest-algorithm`) accepted by Apple's tool are not
 supported and will error.
 
 ## Example signature

--- a/codesign.cpp
+++ b/codesign.cpp
@@ -17,7 +17,8 @@ int main(int argc, char **argv) {
 static int run(int argc, char **argv) {
     CLI::App app{"codesign"};
 
-    std::string identity, identifier, entitlements, timestamp, optionsFlags;
+    std::string identity, identifier, entitlements, timestamp, optionsFlags,
+            preserveMetadata;
     bool force = false;
     bool generateEntitlementDER = false;
     std::vector<std::string> files;
@@ -38,6 +39,9 @@ static int run(int argc, char **argv) {
                  "Timestamp options; only '--timestamp=none' is supported");
     app.add_option("-o,--options", optionsFlags,
                    "Comma-separated signing options; only 'runtime' is supported");
+    app.add_option("--preserve-metadata", preserveMetadata,
+                   "Reuse fields from existing signature; comma-separated list of "
+                   "'identifier', 'entitlements', 'flags'");
     app.add_option("files", files, "Files to sign");
 
     CLI11_PARSE(app, argc, argv);
@@ -72,12 +76,37 @@ static int run(int argc, char **argv) {
         }
     }
 
+    bool preserveIdentifier = false;
+    bool preserveEntitlements = false;
+    bool preserveFlags = false;
+    if (!preserveMetadata.empty()) {
+        size_t start = 0;
+        while (start <= preserveMetadata.size()) {
+            size_t comma = preserveMetadata.find(',', start);
+            if (comma == std::string::npos) comma = preserveMetadata.size();
+            std::string key = preserveMetadata.substr(start, comma - start);
+            if (key == "identifier") preserveIdentifier = true;
+            else if (key == "entitlements") preserveEntitlements = true;
+            else if (key == "flags") preserveFlags = true;
+            else if (!key.empty()) {
+                throw std::runtime_error{
+                        "--preserve-metadata key '" + key + "' is not supported "
+                        "(supported: identifier, entitlements, flags)"};
+            }
+            if (comma == preserveMetadata.size()) break;
+            start = comma + 1;
+        }
+    }
+
     SigTool::Commands::CodesignOptions options{
             .identifier = identifier,
             .entitlements = entitlements,
             .force = force,
             .generateEntitlementDER = generateEntitlementDER,
             .hardenedRuntime = hardenedRuntime,
+            .preserveIdentifier = preserveIdentifier,
+            .preserveEntitlements = preserveEntitlements,
+            .preserveFlags = preserveFlags,
     };
 
     for (const auto &f : files) {

--- a/commands.cpp
+++ b/commands.cpp
@@ -101,7 +101,8 @@ static SuperBlob signMachO(
     }
 
     if (options.hardenedRuntime) {
-        codeDirectory->setHardenedRuntime(target->sdkVersion());
+        codeDirectory->setHardenedRuntime(
+                options.runtimeVersion ? options.runtimeVersion : target->sdkVersion());
     }
 
     auto textSegment = target->getSegment64LoadCommand("__TEXT");
@@ -171,9 +172,14 @@ static SuperBlob signMachO(
         codeDirectory->setSpecialHash(3 /* CSSLOT_RESOURCEDIR */, crHash);
     }
 
-    // optional blob: entitlements
-    if (!options.entitlements.empty()) {
-        std::string plistXml = readFile(options.entitlements);
+    // optional blob: entitlements (raw data takes precedence over file path)
+    std::string plistXml;
+    if (!options.entitlementsData.empty()) {
+        plistXml = options.entitlementsData;
+    } else if (!options.entitlements.empty()) {
+        plistXml = readFile(options.entitlements);
+    }
+    if (!plistXml.empty()) {
         auto entitlements = std::make_shared<Entitlements>(plistXml);
         codeDirectory->setSpecialHash(entitlements->slotType(), hashBlob(entitlements));
         sb.blobs.push_back(entitlements);
@@ -320,6 +326,73 @@ static std::vector<std::vector<uint8_t>> computeCDHashes(const std::string& file
     return out;
 }
 
+// Snapshot of metadata pulled from an existing signature, used to honour
+// --preserve-metadata when re-signing.
+struct ExistingSignature {
+    bool present = false;
+    std::string identifier;
+    std::string entitlementsXml;
+    uint32_t flags = 0;
+    uint32_t runtime = 0;
+};
+
+// Read identifier / entitlements XML / flags / runtime from the first
+// architecture slice that has an embedded SuperBlob. Returns present=false if
+// the binary isn't signed at all.
+static ExistingSignature readExistingSignature(const std::string &filename) {
+    ExistingSignature out{};
+    MachOList list{filename};
+    for (const auto &macho : list.machos) {
+        auto cs = macho->getCodeSignatureLoadCommand();
+        if (!cs) continue;
+
+        std::ifstream in(filename, std::ifstream::binary);
+        if (!in.is_open()) continue;
+        in.seekg(macho->offset + cs->data.dataOff);
+        std::vector<char> buf(cs->data.dataSize);
+        in.read(buf.data(), buf.size());
+        if (static_cast<size_t>(in.gcount()) != buf.size()) continue;
+
+        if (buf.size() < 12) continue;
+        if (readBE32(buf.data()) != CSMAGIC_EMBEDDED_SIGNATURE) continue;
+        uint32_t count = readBE32(buf.data() + 8);
+
+        for (uint32_t i = 0; i < count; i++) {
+            size_t indexEntry = 12 + size_t{i} * 8;
+            if (indexEntry + 8 > buf.size()) break;
+            uint32_t blobOff = readBE32(buf.data() + indexEntry + 4);
+            if (blobOff + 8 > buf.size()) continue;
+            uint32_t blobMagic = readBE32(buf.data() + blobOff);
+            uint32_t blobLen = readBE32(buf.data() + blobOff + 4);
+            if (blobOff + blobLen > buf.size()) continue;
+
+            if (blobMagic == CSMAGIC_CODEDIRECTORY) {
+                if (blobLen < 44) continue;
+                uint32_t version = readBE32(buf.data() + blobOff + 8);
+                out.flags = readBE32(buf.data() + blobOff + 12);
+                uint32_t identOffset = readBE32(buf.data() + blobOff + 20);
+                if (identOffset < blobLen) {
+                    const char *id = buf.data() + blobOff + identOffset;
+                    size_t maxLen = blobLen - identOffset;
+                    size_t idLen = ::strnlen(id, maxLen);
+                    out.identifier.assign(id, idLen);
+                }
+                if (version >= 0x20500 && blobLen >= 92) {
+                    out.runtime = readBE32(buf.data() + blobOff + 88);
+                }
+            } else if (blobMagic == CSMAGIC_EMBEDDED_ENTITLEMENTS) {
+                if (blobLen >= 8) {
+                    out.entitlementsXml.assign(
+                            buf.data() + blobOff + 8, blobLen - 8);
+                }
+            }
+        }
+        out.present = true;
+        return out;
+    }
+    return out;
+}
+
 static std::string inferIdentifier(const std::string& filename) {
     // basename / basename_r are awkward to use. We don't need the exact
     // meaning of basename.
@@ -336,12 +409,11 @@ static std::string inferIdentifier(const std::string& filename) {
 }
 
 // Sign a single Mach-O file in place (handles allocation via codesign_allocate
-// and injection of the new signature).
-static void signOneMachO(const Commands::CodesignOptions &options,
+// and injection of the new signature). `signTemplate` carries everything the
+// CodeDirectory needs; `binaryFile` and `force` are flow control.
+static void signOneMachO(const Commands::SignOptions &signTemplate,
                          const std::string &binaryFile,
-                         const std::string &identifier,
-                         const std::string &infoPlistPath,
-                         const std::string &codeResourcesPath) {
+                         bool force) {
     MachOList list{binaryFile};
     std::vector<std::string> arguments;
 
@@ -349,20 +421,15 @@ static void signOneMachO(const Commands::CodesignOptions &options,
     arguments.emplace_back("-i");
     arguments.emplace_back(binaryFile);
 
+    Commands::SignOptions perFile = signTemplate;
+    perFile.filename = binaryFile;
+
     for (const auto &macho : list.machos) {
         auto codeSignature = macho->getCodeSignatureLoadCommand();
-        if (!options.force && codeSignature) {
+        if (!force && codeSignature) {
             throw std::runtime_error{"file is already signed. pass -f to sign regardless."};
         }
-        auto sb = signMachO(Commands::SignOptions{
-                .filename = binaryFile,
-                .identifier = identifier,
-                .entitlements = options.entitlements,
-                .generateEntitlementDER = options.generateEntitlementDER,
-                .hardenedRuntime = options.hardenedRuntime,
-                .infoPlistPath = infoPlistPath,
-                .codeResourcesPath = codeResourcesPath,
-        }, macho);
+        auto sb = signMachO(perFile, macho);
 
         arguments.emplace_back("-A");
         arguments.emplace_back(std::to_string(macho->header.cpuType));
@@ -421,15 +488,9 @@ static void signOneMachO(const Commands::CodesignOptions &options,
         throw std::runtime_error{std::string{"close: "} + strerror(tempfile)};
     }
 
-    Commands::inject(Commands::SignOptions{
-            .filename = std::string(tempfileName.get()),
-            .identifier = identifier,
-            .entitlements = options.entitlements,
-            .generateEntitlementDER = options.generateEntitlementDER,
-            .hardenedRuntime = options.hardenedRuntime,
-            .infoPlistPath = infoPlistPath,
-            .codeResourcesPath = codeResourcesPath,
-    });
+    Commands::SignOptions injectOpts = signTemplate;
+    injectOpts.filename = std::string(tempfileName.get());
+    Commands::inject(injectOpts);
 
     if (rename(tempfileName.get(), binaryFile.c_str()) != 0) {
         throw std::runtime_error{"rename failed"};
@@ -450,12 +511,43 @@ static void writeFileBytes(const std::string &path, const std::string &bytes) {
 int Commands::codesign(const CodesignOptions &options, const std::string &filename) {
     Bundle bundle = detectBundle(filename);
 
+    // Read existing signature only when at least one --preserve-metadata
+    // category was requested, to avoid an extra parse pass on every call.
+    ExistingSignature preserved{};
+    bool needPreserve = options.preserveIdentifier
+                        || options.preserveEntitlements
+                        || options.preserveFlags;
+    if (needPreserve) {
+        preserved = readExistingSignature(bundle.binaryPath);
+        if (!preserved.present) {
+            throw std::runtime_error{
+                    "--preserve-metadata: '" + bundle.binaryPath
+                    + "' has no existing signature to preserve from"};
+        }
+    }
+
     std::string identifier = options.identifier;
+    if (identifier.empty() && options.preserveIdentifier) {
+        identifier = preserved.identifier;
+    }
     if (identifier.empty()) identifier = bundle.identifier;
     if (identifier.empty()) identifier = inferIdentifier(bundle.binaryPath);
 
+    SignOptions signTemplate{};
+    signTemplate.identifier = identifier;
+    signTemplate.entitlements = options.entitlements;
+    signTemplate.generateEntitlementDER = options.generateEntitlementDER;
+    signTemplate.hardenedRuntime = options.hardenedRuntime;
+    if (options.preserveEntitlements) {
+        signTemplate.entitlementsData = preserved.entitlementsXml;
+    }
+    if (options.preserveFlags && (preserved.flags & CS_RUNTIME)) {
+        signTemplate.hardenedRuntime = true;
+        signTemplate.runtimeVersion = preserved.runtime;
+    }
+
     if (bundle.type == Bundle::Type::Single) {
-        signOneMachO(options, bundle.binaryPath, identifier, "", "");
+        signOneMachO(signTemplate, bundle.binaryPath, options.force);
         return 0;
     }
 
@@ -488,8 +580,9 @@ int Commands::codesign(const CodesignOptions &options, const std::string &filena
     std::string crPath = sigDir + "/CodeResources";
     writeFileBytes(crPath, codeResources);
 
-    signOneMachO(options, bundle.binaryPath, identifier,
-                 bundle.infoPlistPath, crPath);
+    signTemplate.infoPlistPath = bundle.infoPlistPath;
+    signTemplate.codeResourcesPath = crPath;
+    signOneMachO(signTemplate, bundle.binaryPath, options.force);
     return 0;
 }
 };

--- a/commands.h
+++ b/commands.h
@@ -15,6 +15,12 @@ namespace Commands {
         // slots 1 (Info.plist) and 3 (CodeResources). Empty = unused.
         std::string infoPlistPath;
         std::string codeResourcesPath;
+        // Raw entitlements XML; takes precedence over `entitlements` (path)
+        // when non-empty. Used for --preserve-metadata=entitlements.
+        std::string entitlementsData;
+        // Runtime version emitted when hardenedRuntime is set. 0 = derive
+        // from the target's LC_BUILD_VERSION / LC_VERSION_MIN sdk field.
+        uint32_t runtimeVersion;
     };
 
     struct CodesignOptions {
@@ -23,6 +29,11 @@ namespace Commands {
         bool force;
         bool generateEntitlementDER;
         bool hardenedRuntime;
+        // --preserve-metadata categories. When set, fields not explicitly
+        // overridden on the CLI are taken from the existing signature.
+        bool preserveIdentifier;
+        bool preserveEntitlements;
+        bool preserveFlags;
     };
 
     int checkRequiresSignature(const std::string &file);


### PR DESCRIPTION
Reads the existing SuperBlob to extract identifier, entitlements XML, and flags (CS_RUNTIME + runtime version) so they can be reused on re-sign. Other `--preserve-metadata` keys Apple accepts (requirements, team-identifier, runtime, resource-rules, digest-algorithm) are rejected with a clear error.