### PR TITLE
Sign extra Mach-O binaries in bundles as nested code

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ used rather than inheriting from the outer.
 Non-bundle entries directly under those nested-bundle directories are not
 supported and will error.
 
+Extra Mach-O binaries next to the main executable (under `Contents/MacOS/`,
+or at the top level of a framework version) are also treated as nested code:
+they are signed individually and recorded as `cdhash` entries, matching
+Apple's resource rules. Non-Mach-O files there (e.g. shell scripts) are
+sealed by their file hash.
+
 ### Preserving existing metadata
 
 `--preserve-metadata=identifier,entitlements,flags` re-signs a binary while

--- a/resources.cpp
+++ b/resources.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <dirent.h>
 #include <fstream>
+#include <set>
 #include <sstream>
 #include <stdexcept>
 #include <sys/stat.h>
@@ -254,6 +255,70 @@ const char* kRulesSection =
         "\t\t</dict>\n"
         "\t</dict>\n";
 
+bool isMachOFile(const std::string& path) {
+    std::ifstream in(path, std::ifstream::binary);
+    if (!in.is_open()) return false;
+    unsigned char b[4];
+    in.read(reinterpret_cast<char*>(b), 4);
+    if (in.gcount() != 4) return false;
+    uint32_t magic = (uint32_t(b[0]) << 24) | (uint32_t(b[1]) << 16)
+                     | (uint32_t(b[2]) << 8) | uint32_t(b[3]);
+    return magic == 0xfeedfacf || magic == 0xcffaedfe   // MH_MAGIC_64 both orders
+           || magic == 0xcafebabe || magic == 0xbebafeca; // FAT both orders
+}
+
+// The main binary's path relative to contentsRoot (empty if not below it).
+std::string binaryRelativePath(const Bundle& bundle) {
+    if (bundle.binaryPath.size() > bundle.contentsRoot.size() + 1
+        && bundle.binaryPath.compare(0, bundle.contentsRoot.size(),
+                                     bundle.contentsRoot) == 0
+        && bundle.binaryPath[bundle.contentsRoot.size()] == '/') {
+        return bundle.binaryPath.substr(bundle.contentsRoot.size() + 1);
+    }
+    return {};
+}
+
+std::vector<std::string> sortedDirEntries(const std::string& dirPath) {
+    std::vector<std::string> entries;
+    DIR* d = opendir(dirPath.c_str());
+    if (!d) return entries;
+    while (auto* ent = readdir(d)) {
+        std::string n = ent->d_name;
+        if (n == "." || n == "..") continue;
+        entries.push_back(n);
+    }
+    closedir(d);
+    std::sort(entries.begin(), entries.end());
+    return entries;
+}
+
+// Collect Mach-O regular files under `subdir` (recursively; "" = the
+// contentsRoot itself, non-recursive) into `out`, excluding `binaryRel`.
+// Apple's rules2 mark MacOS/ (any depth) and top-level files as nested code
+// (weight 10), so extra executables there must be signed and recorded as
+// cdhash entries rather than sealed by hash.
+void collectMachOFiles(const std::string& contentsRoot,
+                       const std::string& subdir,
+                       const std::string& binaryRel,
+                       std::vector<std::string>& out) {
+    std::string dirPath =
+            subdir.empty() ? contentsRoot : (contentsRoot + "/" + subdir);
+    for (const auto& n : sortedDirEntries(dirPath)) {
+        std::string rel = subdir.empty() ? n : (subdir + "/" + n);
+        std::string full = contentsRoot + "/" + rel;
+        struct stat st{};
+        if (lstat(full.c_str(), &st) != 0) continue;
+        if (S_ISLNK(st.st_mode)) continue;
+        if (S_ISDIR(st.st_mode)) {
+            if (!subdir.empty()) collectMachOFiles(contentsRoot, rel, binaryRel, out);
+            continue;
+        }
+        if (!S_ISREG(st.st_mode)) continue;
+        if (rel == binaryRel) continue;
+        if (isMachOFile(full)) out.push_back(rel);
+    }
+}
+
 } // namespace
 
 std::vector<std::string> findNestedBundles(const Bundle& bundle) {
@@ -298,6 +363,15 @@ std::vector<std::string> findNestedBundles(const Bundle& bundle) {
             }
         }
     }
+
+    // Extra Mach-O binaries next to the main one (MacOS/, or the top level
+    // for frameworks) are nested code under Apple's rules and must carry
+    // their own signature. Non-Mach-O files there (scripts etc.) stay
+    // sealed by hash, which Apple's verifier accepts.
+    std::string binaryRel = binaryRelativePath(bundle);
+    collectMachOFiles(bundle.contentsRoot, "MacOS", binaryRel, out);
+    collectMachOFiles(bundle.contentsRoot, "", binaryRel, out);
+
     return out;
 }
 
@@ -311,12 +385,7 @@ std::string generateCodeResources(const Bundle& bundle,
     }
 
     // Compute the binary's path RELATIVE to contentsRoot.
-    std::string binaryRel;
-    if (bundle.binaryPath.size() > bundle.contentsRoot.size() + 1
-        && bundle.binaryPath.compare(0, bundle.contentsRoot.size(), bundle.contentsRoot) == 0
-        && bundle.binaryPath[bundle.contentsRoot.size()] == '/') {
-        binaryRel = bundle.binaryPath.substr(bundle.contentsRoot.size() + 1);
-    }
+    std::string binaryRel = binaryRelativePath(bundle);
 
     bool omitRootInfoPlist = (bundle.type == Bundle::Type::App);
 
@@ -327,8 +396,12 @@ std::string generateCodeResources(const Bundle& bundle,
     // Filter and sort.
     std::vector<std::string> kept;
     kept.reserve(files.size());
+    std::set<std::string> nestedPaths;
+    for (const auto& n : nested) nestedPaths.insert(n.relativePath);
     for (const auto& rel : files) {
         if (isOmitted(rel, binaryRel, omitRootInfoPlist)) continue;
+        // Files signed as nested code are recorded as cdhash entries only.
+        if (nestedPaths.count(rel)) continue;
         kept.push_back(rel);
     }
     std::sort(kept.begin(), kept.end());

--- a/resources.h
+++ b/resources.h
@@ -19,10 +19,12 @@ struct NestedCdHash {
     std::vector<std::vector<uint8_t>> cdhashes;
 };
 
-// Discover nested bundles directly under known nested-bundle directories
-// (Frameworks/, SharedFrameworks/, PlugIns/, Plug-ins/, XPCServices/,
-// Helpers/) under the given bundle's contentsRoot. Returns relative paths
-// suitable for both signing-each-nested and emitting cdhash entries later.
+// Discover nested code under the given bundle's contentsRoot: bundles and
+// files directly under known nested-bundle directories (Frameworks/,
+// SharedFrameworks/, PlugIns/, Plug-ins/, XPCServices/, Helpers/), plus
+// extra Mach-O binaries under MacOS/ (any depth) and at the top level.
+// Returns relative paths suitable for both signing-each-nested and emitting
+// cdhash entries later.
 std::vector<std::string> findNestedBundles(const Bundle& bundle);
 
 // Generate a CodeResources XML plist for the given bundle. Hashes regular

--- a/test/test.sh
+++ b/test/test.sh
@@ -158,6 +158,11 @@ make_bundle_fixture() {
   # Loose dylib directly under Frameworks/
   cp tmp/libnested.dylib "$c/Frameworks/libnested.dylib"
 
+  # Second Mach-O binary and a shell script next to the main executable
+  cp tmp/libnested.dylib "$c/MacOS/helper"
+  printf '#!/bin/sh\necho x\n' > "$c/MacOS/script.sh"
+  chmod +x "$c/MacOS/script.sh"
+
   # Nested XPC service
   local xpc=$c/XPCServices/Svc.xpc
   mkdir -p "$xpc/Contents/MacOS" "$xpc/Contents/Resources"
@@ -187,7 +192,7 @@ check_bundle() {
   # must record them as cdhash entries rather than plain file hashes.
   if [ "$fail" -eq 0 ]; then
     local cr=$app/Contents/_CodeSignature/CodeResources
-    for entry in Frameworks/Foo.framework Frameworks/libnested.dylib XPCServices/Svc.xpc; do
+    for entry in Frameworks/Foo.framework Frameworks/libnested.dylib XPCServices/Svc.xpc MacOS/helper; do
       if ! grep -A2 "<key>$entry</key>" "$cr" | grep -q '<key>cdhash</key>'; then
         echo "FAIL: no cdhash entry for $entry in $name"
         fail=1
@@ -199,6 +204,16 @@ check_bundle() {
     fi
     if grep -q 'locversion.plist</key>' "$cr"; then
       echo "FAIL: locversion.plist should be omitted from $name"
+      fail=1
+    fi
+    # Extra Mach-O binaries must carry their own valid signature; plain
+    # scripts next to the binary stay sealed by hash.
+    if ! $APPLE_CODESIGN --verify --strict "$app/Contents/MacOS/helper"; then
+      echo "FAIL: MacOS/helper is not validly signed in $name"
+      fail=1
+    fi
+    if ! grep -A2 '<key>MacOS/script.sh</key>' "$cr" | grep -q '<key>hash2</key>'; then
+      echo "FAIL: no hash2 entry for MacOS/script.sh in $name"
       fail=1
     fi
     for pair in "$app:com.example.nested" \


### PR DESCRIPTION
Apple's resource rules treat MacOS/ (at any depth) and top-level bundle files as nested code, so a second executable next to the main one must carry its own signature and be recorded in CodeResources as a cdhash entry. Previously such binaries were sealed by file hash and left unsigned, which verifies but leaves them unable to run on arm64.

findNestedBundles now also returns Mach-O regular files found under MacOS/ and at the top level of the contents root (excluding the main binary), which the bundle flow already signs individually. Non-Mach-O files there (e.g. shell scripts) remain sealed by hash, which Apple's verifier accepts.