### PR TITLE
Match Apple's --preserve-metadata=flags behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,10 @@ reusing fields from its existing signature. Supported keys:
   - `identifier` — reuse the existing CodeDirectory identifier (CLI `-i` still
     wins if both are passed)
   - `entitlements` — reuse the existing XML entitlements blob
-  - `flags` — preserve `CS_RUNTIME` (and its associated runtime SDK version)
-    from the original signature; other flag bits are not propagated
+  - `flags` — preserve the option flags from the original signature (`hard`,
+    `kill`, `restrict`, `library-validation`, `runtime` with its SDK version,
+    ...). An explicit `-o`/`--options` on the command line replaces the
+    preserved flags entirely, matching Apple's behaviour
 
 The binary must already be signed; otherwise `codesign` errors. Other
 `--preserve-metadata` keys (`requirements`, `team-identifier`, `runtime`,

--- a/codesign.cpp
+++ b/codesign.cpp
@@ -104,6 +104,7 @@ static int run(int argc, char **argv) {
             .force = force,
             .generateEntitlementDER = generateEntitlementDER,
             .hardenedRuntime = hardenedRuntime,
+            .optionsSpecified = !optionsFlags.empty(),
             .preserveIdentifier = preserveIdentifier,
             .preserveEntitlements = preserveEntitlements,
             .preserveFlags = preserveFlags,

--- a/commands.cpp
+++ b/commands.cpp
@@ -100,6 +100,10 @@ static SuperBlob signMachO(
         codeDirectory->data.execSegFlags |= CS_EXECSEG_MAIN_BINARY;
     }
 
+    if (options.extraFlags) {
+        codeDirectory->data.flags |= options.extraFlags;
+    }
+
     if (options.hardenedRuntime) {
         codeDirectory->setHardenedRuntime(
                 options.runtimeVersion ? options.runtimeVersion : target->sdkVersion());
@@ -543,9 +547,15 @@ int Commands::codesign(const CodesignOptions &options, const std::string &filena
     if (options.preserveEntitlements && options.entitlements.empty()) {
         signTemplate.entitlementsData = preserved.entitlementsXml;
     }
-    if (options.preserveFlags && (preserved.flags & CS_RUNTIME)) {
-        signTemplate.hardenedRuntime = true;
-        signTemplate.runtimeVersion = preserved.runtime;
+    // Apple semantics: an explicit -o/--options replaces the preserved flags
+    // entirely; otherwise every option flag bit is carried over verbatim.
+    if (options.preserveFlags && !options.optionsSpecified) {
+        signTemplate.extraFlags =
+                preserved.flags & (CS_PRESERVABLE_FLAGS & ~uint32_t{CS_RUNTIME});
+        if (preserved.flags & CS_RUNTIME) {
+            signTemplate.hardenedRuntime = true;
+            signTemplate.runtimeVersion = preserved.runtime;
+        }
     }
 
     if (bundle.type == Bundle::Type::Single) {

--- a/commands.h
+++ b/commands.h
@@ -21,6 +21,10 @@ namespace Commands {
         // Runtime version emitted when hardenedRuntime is set. 0 = derive
         // from the target's LC_BUILD_VERSION / LC_VERSION_MIN sdk field.
         uint32_t runtimeVersion;
+        // Additional CodeDirectory flag bits to set (CS_HARD, CS_KILL, ...).
+        // CS_RUNTIME is requested via hardenedRuntime instead, since it also
+        // needs the version bump and runtime field.
+        uint32_t extraFlags;
     };
 
     struct CodesignOptions {
@@ -29,6 +33,9 @@ namespace Commands {
         bool force;
         bool generateEntitlementDER;
         bool hardenedRuntime;
+        // True when -o/--options was passed on the CLI. An explicit -o
+        // replaces preserved flags entirely (Apple semantics).
+        bool optionsSpecified;
         // --preserve-metadata categories. When set, fields not explicitly
         // overridden on the CLI are taken from the existing signature.
         bool preserveIdentifier;

--- a/magic_numbers.h
+++ b/magic_numbers.h
@@ -5,7 +5,19 @@ namespace SigTool {
 
 enum {
     CS_ADHOC = 0x00000002,
+    CS_HARD = 0x00000100,
+    CS_KILL = 0x00000200,
+    CS_CHECK_EXPIRATION = 0x00000400,
+    CS_RESTRICT = 0x00000800,
+    CS_ENFORCEMENT = 0x00001000,
+    CS_REQUIRE_LV = 0x00002000,
     CS_RUNTIME = 0x00010000,
+
+    // Option flag bits Apple's codesign carries over verbatim for
+    // --preserve-metadata=flags.
+    CS_PRESERVABLE_FLAGS = CS_HARD | CS_KILL | CS_CHECK_EXPIRATION
+                           | CS_RESTRICT | CS_ENFORCEMENT | CS_REQUIRE_LV
+                           | CS_RUNTIME,
 };
 
 enum {

--- a/test/test.sh
+++ b/test/test.sh
@@ -224,6 +224,71 @@ check_bundle() {
   echo
 }
 
+# Re-sign a binary that Apple's codesign signed with option flags and
+# entitlements, preserving its metadata; identifier, flags (including the
+# runtime version) and entitlements must survive. An explicit -o must replace
+# the preserved flags, matching Apple's semantics.
+check_preserve_metadata() {
+  local name=preserve-metadata
+  local bin=tmp/preserve
+
+  echo "Checking --preserve-metadata against Apple's semantics"
+
+  cp tmp/test.arm64-darwin "$bin"
+  $APPLE_CODESIGN --remove-signature "$bin"
+  $APPLE_CODESIGN -s - -i com.example.preserve \
+      --entitlements entitlements.plist -o runtime,library,kill "$bin"
+  local before
+  before=$($APPLE_CODESIGN -dvvv "$bin" 2>&1 | grep -oE 'flags=[^ ]+')
+
+  local fail=0
+  if ! $OUR_CODESIGN -s - -f --preserve-metadata=identifier,entitlements,flags "$bin"; then
+    echo "FAIL: our codesign failed re-signing $bin"
+    fail=1
+  else
+    local info after
+    info=$($APPLE_CODESIGN -dvvv "$bin" 2>&1)
+    after=$(grep -oE 'flags=[^ ]+' <<<"$info")
+    if [ "$before" != "$after" ]; then
+      echo "FAIL: flags not preserved: before=$before after=$after"
+      fail=1
+    fi
+    if ! grep -q '^Identifier=com.example.preserve$' <<<"$info"; then
+      echo "FAIL: identifier not preserved"
+      fail=1
+    fi
+    if ! $APPLE_CODESIGN -d --entitlements - "$bin" 2>/dev/null \
+        | grep -q com.apple.security.cs.allow-jit; then
+      echo "FAIL: entitlements not preserved"
+      fail=1
+    fi
+    if ! $APPLE_CODESIGN --verify --strict "$bin"; then
+      echo "FAIL: codesign --verify rejected the preserved re-sign"
+      fail=1
+    fi
+
+    # An explicit -o replaces the preserved flags entirely.
+    if ! $OUR_CODESIGN -s - -f --preserve-metadata=flags -o runtime "$bin"; then
+      echo "FAIL: our codesign failed with --preserve-metadata=flags -o runtime"
+      fail=1
+    else
+      after=$($APPLE_CODESIGN -dvvv "$bin" 2>&1 | grep -oE 'flags=0x[0-9a-f]+')
+      if [ "$after" != "flags=0x10002" ]; then
+        echo "FAIL: explicit -o did not replace preserved flags: $after"
+        fail=1
+      fi
+    fi
+  fi
+
+  if [ "$fail" -eq 0 ]; then
+    echo "OK: $name"
+  else
+    failures+=("$name")
+  fi
+
+  echo
+}
+
 for f in "${files[@]}"; do
   resign "$f"
 done
@@ -233,6 +298,7 @@ for f in "${files[@]}"; do
 done
 
 check_bundle
+check_preserve_metadata
 
 if [ "${#failures[@]}" -eq 0 ]; then
   exit 0


### PR DESCRIPTION
Previously only CS_RUNTIME survived a --preserve-metadata=flags re-sign. Apple's codesign carries every option flag bit over verbatim (hard, kill, expires, restrict, enforcement, library-validation, runtime with its SDK version), and an explicit -o/--options on the command line replaces the preserved flags entirely. Do the same: copy the preservable flag mask from the existing CodeDirectory unless -o was given, and OR it into the new one.

Verified against /usr/bin/codesign: flags signed as runtime,library,kill,hard,restrict round-trip identically, and --preserve-metadata=flags -o runtime yields exactly adhoc,runtime.